### PR TITLE
Robust gz extraction

### DIFF
--- a/src/importer.rs
+++ b/src/importer.rs
@@ -97,7 +97,9 @@ impl Importer {
             .open_filename(path.to_str().unwrap(), BUFFER_SIZE)
             .unwrap();
           while let Ok(e) = archive_reader.next_header() {
-            if e.pathname().ends_with(".pdf") { continue; }
+            if e.pathname().ends_with(".pdf") {
+              continue;
+            }
             let full_extract_path = path_str.to_string() + &e.pathname();
             match fs::metadata(full_extract_path.clone()) {
               Ok(_) => println!("File {:?} exists, won't unpack.", e.pathname()),
@@ -198,8 +200,9 @@ impl Importer {
             .unwrap()
             .support_filter_all()
             .support_format_all()
-            .open_filename(entry_path, BUFFER_SIZE) {
-            Err(_) => {raw_read_needed = true},
+            .open_filename(entry_path, BUFFER_SIZE)
+          {
+            Err(_) => raw_read_needed = true,
             Ok(archive_reader) => {
               let mut file_count = 0;
               while let Ok(e) = archive_reader.next_header() {
@@ -216,7 +219,7 @@ impl Importer {
                 // Special case (bug? in libarchive crate), single file in .gz
                 raw_read_needed = true;
               }
-            }
+            },
           }
 
           if raw_read_needed {
@@ -226,13 +229,11 @@ impl Importer {
               .support_format_raw()
               .open_filename(entry_path, BUFFER_SIZE);
             match raw_reader_new {
-              Ok(raw_reader) => {
-                match raw_reader.next_header() {
-                  Ok(_) => {
-                    single_file_transfer(&default_tex_target, &raw_reader, &mut archive_writer_new);
-                  },
-                  Err(_) => println!("No content in archive: {:?}", entry_path),
-                }
+              Ok(raw_reader) => match raw_reader.next_header() {
+                Ok(_) => {
+                  single_file_transfer(&default_tex_target, &raw_reader, &mut archive_writer_new);
+                },
+                Err(_) => println!("No content in archive: {:?}", entry_path),
               },
               Err(_) => println!("Unrecognizeable archive: {:?}", entry_path),
             }
@@ -343,7 +344,6 @@ impl Importer {
 
 /// Transfer the data contained within `Reader` to a `Writer`, assuming it was a single file
 pub fn single_file_transfer(tex_target: &str, reader: &Reader, writer: &mut Writer) {
-  println!("adding to zip: {:?}", tex_target);
   // In a "raw" read, we don't know the data size in advance. So we bite the
   // bullet and read the usually tiny tex file in memory,
   // obtaining a size estimate
@@ -353,7 +353,9 @@ pub fn single_file_transfer(tex_target: &str, reader: &Reader, writer: &mut Writ
   }
   let mut ok_header = false;
   match writer.write_header_new(&tex_target, raw_data.len() as i64) {
-    Ok(_) => { ok_header = true; },
+    Ok(_) => {
+      ok_header = true;
+    },
     Err(e) => {
       println!("Couldn't write header: {:?}", e);
     },
@@ -361,11 +363,7 @@ pub fn single_file_transfer(tex_target: &str, reader: &Reader, writer: &mut Writ
   if ok_header {
     match writer.write_data(raw_data) {
       Ok(_) => {},
-      Err(e) => println!(
-        "Failed to write data to {:?} because {:?}",
-        tex_target,
-        e
-      ),
+      Err(e) => println!("Failed to write data to {:?} because {:?}", tex_target, e),
     };
   }
 }

--- a/src/importer.rs
+++ b/src/importer.rs
@@ -97,6 +97,7 @@ impl Importer {
             .open_filename(path.to_str().unwrap(), BUFFER_SIZE)
             .unwrap();
           while let Ok(e) = archive_reader.next_header() {
+            if e.pathname().ends_with(".pdf") { continue; }
             let full_extract_path = path_str.to_string() + &e.pathname();
             match fs::metadata(full_extract_path.clone()) {
               Ok(_) => println!("File {:?} exists, won't unpack.", e.pathname()),
@@ -142,7 +143,7 @@ impl Importer {
                 match fs::metadata(dir_extract_path) {
                   Ok(_) => {}//println!("Directory for {:?} already exists, won't unpack.", e.pathname()),
                   Err(_) => {
-                    println!("To unpack: {:?}", full_extract_path);
+                    // println!("To unpack: {:?}", full_extract_path);
                     match e.extract_to(&full_extract_path, Vec::new()) {
                       Ok(_) => {}
                       _ => {
@@ -172,6 +173,7 @@ impl Importer {
           let entry_path = path.to_str().unwrap();
           let entry_dir = path.parent().unwrap().to_str().unwrap();
           let base_name = path.file_stem().unwrap().to_str().unwrap();
+          let default_tex_target = base_name.to_string() + ".tex";
           let entry_cp_dir = entry_dir.to_string() + "/" + base_name;
           fs::create_dir_all(entry_cp_dir.clone()).unwrap_or_else(|reason| {
             println!(
@@ -180,86 +182,64 @@ impl Importer {
               reason.kind()
             );
           });
-          // Careful here, some of arXiv's .gz files are really plain-text TeX files (surprise!!!)
-          let archive_reader_new = Reader::new()
-            .unwrap()
-            .support_filter_all()
-            .support_format_all()
-            .open_filename(entry_path, BUFFER_SIZE);
+          println!("\nVisiting: {:?}", path);
           // We'll write out a ZIP file for each entry
           let full_extract_path = entry_cp_dir.to_string() + "/" + base_name + ".zip";
           let mut archive_writer_new = Writer::new().unwrap()
             //.add_filter(ArchiveFilter::Lzip)
-            .set_compression(ArchiveFilter::None)
+            // .set_compression(ArchiveFilter::None)
             .set_format(ArchiveFormat::Zip);
           archive_writer_new
             .open_filename(&full_extract_path.clone())
             .unwrap();
 
-          match archive_reader_new {
-            Err(_) => {
-              let raw_reader_new = Reader::new()
-                .unwrap()
-                .support_filter_all()
-                .support_format_raw()
-                .open_filename(entry_path, BUFFER_SIZE);
-              match raw_reader_new {
-                Ok(raw_reader) => {
-                  match raw_reader.next_header() {
-                    Ok(_) => {
-                      let tex_target = base_name.to_string() + ".tex";
-                      // In a "raw" read, we don't know the data size in advance. So we bite the
-                      // bullet and read the usually tiny tex file in memory,
-                      // obtaining a size estimate
-                      let mut raw_data = Vec::new();
-                      loop {
-                        let chunk_data = raw_reader.read_data(BUFFER_SIZE);
-                        match chunk_data {
-                          Ok(chunk) => raw_data.extend(chunk.into_iter()),
-                          Err(_) => break,
-                        };
-                      }
-                      match archive_writer_new.write_header_new(&tex_target, raw_data.len() as i64)
-                      {
-                        Ok(_) => {},
-                        Err(e) => {
-                          println!("Couldn't write header: {:?}", e);
-                          break;
-                        },
-                      }
-                      match archive_writer_new.write_data(raw_data) {
-                        Ok(_) => {},
-                        Err(e) => println!(
-                          "Failed to write data to {:?} because {:?}",
-                          tex_target.clone(),
-                          e
-                        ),
-                      };
-                    },
-                    Err(_) => println!("No content in archive: {:?}", entry_path),
-                  }
-                },
-                Err(_) => println!("Unrecognizeable archive: {:?}", entry_path),
-              }
-            },
+          // Careful here, some of arXiv's .gz files are really plain-text TeX files (surprise!!!)
+          let mut raw_read_needed = false;
+          match Reader::new()
+            .unwrap()
+            .support_filter_all()
+            .support_format_all()
+            .open_filename(entry_path, BUFFER_SIZE) {
+            Err(_) => {raw_read_needed = true},
             Ok(archive_reader) => {
+              println!("multi-file .gz");
+              let mut file_count = 0;
               while let Ok(e) = archive_reader.next_header() {
+                println!("header: {:?}", e.pathname());
+                file_count += 1;
                 match archive_writer_new.write_header(e) {
-                  _ => {}, // TODO: If we need to print an error message, we can do so later.
+                  Ok(_) => {}, // TODO: If we need to print an error message, we can do so later.
+                  Err(e2) => println!("Header write failed: {:?}", e2),
                 };
-                loop {
-                  let entry_data = archive_reader.read_data(BUFFER_SIZE);
-                  match entry_data {
-                    Ok(chunk) => {
-                      archive_writer_new.write_data(chunk).unwrap();
-                    },
-                    Err(_) => {
-                      break;
-                    },
-                  };
+                while let Ok(chunk) = archive_reader.read_data(BUFFER_SIZE) {
+                  archive_writer_new.write_data(chunk).unwrap();
                 }
               }
-            },
+              if file_count == 0 {
+                // Special case (bug? in libarchive crate), single file in .gz
+                raw_read_needed = true;
+              }
+            }
+          }
+
+          if raw_read_needed {
+            let raw_reader_new = Reader::new()
+              .unwrap()
+              .support_filter_all()
+              .support_format_raw()
+              .open_filename(entry_path, BUFFER_SIZE);
+            match raw_reader_new {
+              Ok(raw_reader) => {
+                println!("format_raw .gz");
+                match raw_reader.next_header() {
+                  Ok(_) => {
+                    single_file_transfer(&default_tex_target, &raw_reader, &mut archive_writer_new);
+                  },
+                  Err(_) => println!("No content in archive: {:?}", entry_path),
+                }
+              },
+              Err(_) => println!("Unrecognizeable archive: {:?}", entry_path),
+            }
           }
           // Done with this .gz , remove it:
           match fs::remove_file(path.clone()) {
@@ -362,5 +342,34 @@ impl Importer {
     // the "Backend::mark_imported" ORM method allows us to insert only if new
     try!(self.walk_import());
     Ok(())
+  }
+}
+
+/// Transfer the data contained within `Reader` to a `Writer`, assuming it was a single file
+pub fn single_file_transfer(tex_target: &str, reader: &Reader, writer: &mut Writer) {
+  println!("adding to zip: {:?}", tex_target);
+  // In a "raw" read, we don't know the data size in advance. So we bite the
+  // bullet and read the usually tiny tex file in memory,
+  // obtaining a size estimate
+  let mut raw_data = Vec::new();
+  while let Ok(chunk) = reader.read_data(BUFFER_SIZE) {
+    raw_data.extend(chunk.into_iter());
+  }
+  let mut ok_header = false;
+  match writer.write_header_new(&tex_target, raw_data.len() as i64) {
+    Ok(_) => { ok_header = true; },
+    Err(e) => {
+      println!("Couldn't write header: {:?}", e);
+    },
+  }
+  if ok_header {
+    match writer.write_data(raw_data) {
+      Ok(_) => {},
+      Err(e) => println!(
+        "Failed to write data to {:?} because {:?}",
+        tex_target,
+        e
+      ),
+    };
   }
 }

--- a/src/importer.rs
+++ b/src/importer.rs
@@ -182,7 +182,6 @@ impl Importer {
               reason.kind()
             );
           });
-          println!("\nVisiting: {:?}", path);
           // We'll write out a ZIP file for each entry
           let full_extract_path = entry_cp_dir.to_string() + "/" + base_name + ".zip";
           let mut archive_writer_new = Writer::new().unwrap()
@@ -202,10 +201,8 @@ impl Importer {
             .open_filename(entry_path, BUFFER_SIZE) {
             Err(_) => {raw_read_needed = true},
             Ok(archive_reader) => {
-              println!("multi-file .gz");
               let mut file_count = 0;
               while let Ok(e) = archive_reader.next_header() {
-                println!("header: {:?}", e.pathname());
                 file_count += 1;
                 match archive_writer_new.write_header(e) {
                   Ok(_) => {}, // TODO: If we need to print an error message, we can do so later.
@@ -230,7 +227,6 @@ impl Importer {
               .open_filename(entry_path, BUFFER_SIZE);
             match raw_reader_new {
               Ok(raw_reader) => {
-                println!("format_raw .gz");
                 match raw_reader.next_header() {
                   Ok(_) => {
                     single_file_transfer(&default_tex_target, &raw_reader, &mut archive_writer_new);


### PR DESCRIPTION
Caught a bug with my use of libarchive that failed to extract `.gz` archives with exactly one custom-named file. This PR fixes that oversight.