### PR TITLE
per-service worker monitoring infrastructure

### DIFF
--- a/bin/frontend.rs
+++ b/bin/frontend.rs
@@ -215,13 +215,14 @@ fn worker_report(service_name: String) -> Result<Template, NotFound<String>> {
     let mut global = HashMap::new();
     global.insert(
       "title".to_string(),
-      "Registered services for ".to_string() + &service_name,
+      format!("Worker report for service {} ", &service_name),
     );
     global.insert(
       "description".to_string(),
-      "An analysis framework for corpora of TeX/LaTeX documents - registered services for "
-        .to_string()
-        + &service_name,
+      format!(
+        "Worker report for service {} as registered by the CorTeX dispatcher",
+        &service_name
+      ),
     );
     global.insert("service_name".to_string(), service_name.to_string());
     global.insert(

--- a/migrations/2017-10-01-204006_tasks/up.sql
+++ b/migrations/2017-10-01-204006_tasks/up.sql
@@ -1,5 +1,6 @@
 -- Your SQL goes here
-CREATE TABLE tasks (
+CREATE TABLE tasks
+(
   id BIGSERIAL PRIMARY KEY,
   service_id INTEGER NOT NULL,
   corpus_id INTEGER NOT NULL,

--- a/migrations/2018-08-16-200128_worker_metadata/down.sql
+++ b/migrations/2018-08-16-200128_worker_metadata/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE worker_metadata;

--- a/migrations/2018-08-16-200128_worker_metadata/up.sql
+++ b/migrations/2018-08-16-200128_worker_metadata/up.sql
@@ -1,0 +1,16 @@
+CREATE TABLE worker_metadata
+(
+  id SERIAL PRIMARY KEY,
+  service_id INTEGER NOT NULL,
+  last_dispatched_task_id BIGINT NOT NULL,
+  last_returned_task_id BIGINT,
+  total_dispatched INTEGER NOT NULL DEFAULT 0,
+  total_returned INTEGER NOT NULL DEFAULT 0,
+  first_seen TIMESTAMP NOT NULL,
+  session_seen TIMESTAMP,
+  time_last_dispatch TIMESTAMP NOT NULL,
+  time_last_return TIMESTAMP,
+  name varchar(200) NOT NULL
+);
+create unique index worker_id_idx on worker_metadata(name, service_id);
+create index worker_service_idx on worker_metadata(service_id);

--- a/src/dispatcher/metadata.rs
+++ b/src/dispatcher/metadata.rs
@@ -1,0 +1,17 @@
+use backend;
+
+enum EventKind {
+  Send,
+  Receive,
+}
+
+pub struct Event {
+  pub kind: EventKind,
+  pub time: String,
+  pub valid: bool,
+  pub task: String,
+  pub service: String,
+  pub identity: String,
+}
+
+pub fn register_event(e: Event) {}

--- a/src/dispatcher/sink.rs
+++ b/src/dispatcher/sink.rs
@@ -17,7 +17,7 @@ use time;
 use dispatcher::server;
 use helpers;
 use helpers::{TaskProgress, TaskReport, TaskStatus};
-use models::Service;
+use models::{Service, WorkerMetadata};
 
 /// Specifies the binding and operation parameters for a ZMQ sink component
 pub struct Sink {
@@ -166,6 +166,13 @@ impl Sink {
                   },
                 }
               }
+              // Also update worker metadata for transparency
+              WorkerMetadata::record_received(
+                identity.to_string(),
+                service.id,
+                taskid,
+                self.backend_address.clone(),
+              )?;
             } else {
               // Otherwise just discard the rest of the message
               println!(

--- a/src/models.rs
+++ b/src/models.rs
@@ -11,7 +11,10 @@ use helpers::TaskStatus;
 use rand::{thread_rng, Rng};
 use std::collections::HashMap;
 use std::fmt;
+use std::thread;
+use std::time::SystemTime;
 
+use backend;
 use concerns::{CortexDeletable, CortexInsertable};
 use diesel::pg::PgConnection;
 use diesel::result::Error;
@@ -25,6 +28,7 @@ use schema::log_invalids;
 use schema::log_warnings;
 use schema::services;
 use schema::tasks;
+use schema::worker_metadata;
 
 // Tasks
 
@@ -449,6 +453,231 @@ impl CortexInsertable for NewLogInvalid {
       .execute(connection)
   }
 }
+
+#[derive(Insertable, Debug)]
+#[table_name = "worker_metadata"]
+/// Metadata collection for workers, updated by the dispatcher upon zmq transactions
+pub struct NewWorkerMetadata {
+  /// associated service for this worker metadata set
+  pub service_id: i32,
+  /// time of last ventilator dispatch to the service
+  pub last_dispatched_task_id: i64,
+  /// time of last sink job received from the service
+  pub last_returned_task_id: Option<i64>,
+  /// dispatch totals
+  pub total_dispatched: i32,
+  /// return totals
+  pub total_returned: i32,
+  /// first registered ventilator request for this worker, coincides with insertion in DB
+  pub first_seen: SystemTime,
+  /// first time seen in the current dispatcher session
+  pub session_seen: Option<SystemTime>,
+  /// time of last dispatched task
+  pub time_last_dispatch: SystemTime,
+  /// time of last returned job result
+  pub time_last_return: Option<SystemTime>,
+  /// identity of this worker, usually hostname:pid
+  pub name: String,
+}
+
+#[derive(Identifiable, Queryable, Clone, Debug, Serialize)]
+#[table_name = "worker_metadata"]
+/// Metadata collection for workers, updated by the dispatcher upon zmq transactions
+pub struct WorkerMetadata {
+  /// task primary key, auto-incremented by postgresql
+  pub id: i32,
+  /// associated service for this worker metadata set
+  pub service_id: i32,
+  /// time of last ventilator dispatch to the service
+  pub last_dispatched_task_id: i64,
+  /// time of last sink job received from the service
+  pub last_returned_task_id: Option<i64>,
+  /// dispatch totals
+  pub total_dispatched: i32,
+  /// return totals
+  pub total_returned: i32,
+  /// first registered ventilator request for this worker, coincides with insertion in DB
+  pub first_seen: SystemTime,
+  /// first time seen in the current dispatcher session
+  pub session_seen: Option<SystemTime>,
+  /// time of last dispatched task
+  pub time_last_dispatch: SystemTime,
+  /// time of last returned job result
+  pub time_last_return: Option<SystemTime>,
+  /// identity of this worker, usually hostname:pid
+  pub name: String,
+}
+
+impl From<WorkerMetadata> for HashMap<String, String> {
+  fn from(worker: WorkerMetadata) -> HashMap<String, String> {
+    let mut wh = HashMap::new();
+    let now = SystemTime::now();
+    wh.insert("id".to_string(), worker.id.to_string());
+    wh.insert("service_id".to_string(), worker.service_id.to_string());
+    wh.insert(
+      "last_dispatched_task_id".to_string(),
+      worker.last_dispatched_task_id.to_string(),
+    );
+    wh.insert(
+      "last_returned_task_id".to_string(),
+      match worker.last_returned_task_id {
+        Some(id) => id.to_string(),
+        _ => String::new(),
+      },
+    );
+    wh.insert(
+      "total_dispatched".to_string(),
+      worker.total_dispatched.to_string(),
+    );
+    wh.insert(
+      "total_returned".to_string(),
+      worker.total_returned.to_string(),
+    );
+
+    let first_seen_ago = now.duration_since(worker.first_seen).unwrap();
+    let first_seen_ago_str = if first_seen_ago.as_secs() <= 60 {
+      format!("{} seconds ago", first_seen_ago.as_secs())
+    } else {
+      format!("{} minutes ago", first_seen_ago.as_secs() / 60)
+    };
+    wh.insert("first_seen".to_string(), first_seen_ago_str);
+
+    if let Some(session_seen) = worker.session_seen {
+      let session_seen_ago = now.duration_since(session_seen).unwrap();
+      let session_seen_ago_str = if session_seen_ago.as_secs() <= 60 {
+        format!("{} seconds ago", session_seen_ago.as_secs())
+      } else {
+        format!("{} minutes ago", session_seen_ago.as_secs() / 60)
+      };
+      wh.insert("session_seen".to_string(), session_seen_ago_str);
+    } else {
+      wh.insert("session_seen".to_string(), String::new());
+    }
+
+    let dispatch_ago = now.duration_since(worker.time_last_dispatch).unwrap();
+    let dispatch_ago_str = if dispatch_ago.as_secs() <= 60 {
+      format!("{} seconds ago", dispatch_ago.as_secs())
+    } else {
+      format!("{} minutes ago", dispatch_ago.as_secs() / 60)
+    };
+    wh.insert("time_last_dispatch".to_string(), dispatch_ago_str);
+    if let Some(time_last_return) = worker.time_last_return {
+      let return_ago = now.duration_since(time_last_return).unwrap();
+      let return_ago_str = if return_ago.as_secs() <= 60 {
+        format!("{} seconds ago", return_ago.as_secs())
+      } else {
+        format!("{} minutes ago", return_ago.as_secs() / 60)
+      };
+
+      wh.insert("time_last_return".to_string(), return_ago_str);
+    } else {
+      wh.insert("time_last_return".to_string(), String::new());
+    }
+    wh.insert("name".to_string(), worker.name.to_string());
+    wh
+  }
+}
+impl WorkerMetadata {
+  /// Update the metadata for a worker which was just dispatched to
+  pub fn record_dispatched(
+    name: String,
+    service_id: i32,
+    last_dispatched_task_id: i64,
+    backend_address: String,
+  ) -> Result<(), Error>
+  {
+    let now = SystemTime::now();
+    let _ = thread::spawn(move || {
+      let backend = backend::from_address(&backend_address);
+      match WorkerMetadata::find_by_name(&name, service_id, &backend.connection) {
+        Ok(data) => {
+          // update with the appropriate fields.
+          let session_seen = match data.session_seen {
+            Some(time) => time,
+            None => now.clone(),
+          };
+          use schema::worker_metadata;
+          update(&data)
+            .set((
+              worker_metadata::last_dispatched_task_id.eq(last_dispatched_task_id),
+              worker_metadata::total_dispatched.eq(worker_metadata::total_dispatched + 1),
+              worker_metadata::time_last_dispatch.eq(now.clone()),
+              worker_metadata::session_seen.eq(Some(session_seen)),
+            )).execute(&backend.connection)
+            .unwrap_or(0);
+        },
+        _ => {
+          let data = NewWorkerMetadata {
+            name,
+            service_id,
+            last_dispatched_task_id,
+            last_returned_task_id: None,
+            total_dispatched: 1,
+            total_returned: 0,
+            first_seen: now.clone(),
+            session_seen: Some(now.clone()),
+            time_last_dispatch: now.clone(),
+            time_last_return: None,
+          };
+          insert_into(worker_metadata::table)
+            .values(&data)
+            .execute(&backend.connection)
+            .unwrap_or(0);
+        },
+      }
+    });
+    Ok(())
+  }
+  /// Update the metadata for a worker which was just received from
+  pub fn record_received(
+    identity: String,
+    service_id: i32,
+    last_returned_task_id: i64,
+    backend_address: String,
+  ) -> Result<(), Error>
+  {
+    let now = SystemTime::now();
+    let _ = thread::spawn(move || {
+      let backend = backend::from_address(&backend_address);
+      if let Ok(data) = WorkerMetadata::find_by_name(&identity, service_id, &backend.connection) {
+        let session_seen = match data.session_seen {
+          Some(time) => time,
+          None => now.clone(),
+        };
+        use schema::worker_metadata;
+        update(&data)
+          .set((
+            worker_metadata::last_returned_task_id.eq(last_returned_task_id),
+            worker_metadata::total_returned.eq(worker_metadata::total_returned + 1),
+            worker_metadata::time_last_return.eq(now.clone()),
+            worker_metadata::session_seen.eq(Some(session_seen)),
+          )).execute(&backend.connection)
+          .unwrap_or(0);
+      } else {
+        println!(
+          "-- Can't record worker metadata for unknown worker: {:?} {:?}",
+          identity, service_id
+        );
+      }
+    });
+    Ok(())
+  }
+
+  /// Load worker metadata record by identity and service id
+  pub fn find_by_name(
+    identity: &str,
+    sid: i32,
+    connection: &PgConnection,
+  ) -> Result<WorkerMetadata, Error>
+  {
+    use schema::worker_metadata::{name, service_id};
+    worker_metadata::table
+      .filter(name.eq(identity))
+      .filter(service_id.eq(sid))
+      .get_result(connection)
+  }
+}
+
 // Services
 #[derive(Identifiable, Queryable, AsChangeset, Clone, Debug)]
 /// A `CorTeX` processing service
@@ -530,6 +759,15 @@ impl Service {
     );
     hm.insert("complex".to_string(), self.complex.to_string());
     hm
+  }
+
+  /// Return a vector of services currently activated on this corpus
+  pub fn select_workers(&self, connection: &PgConnection) -> Result<Vec<WorkerMetadata>, Error> {
+    let workers_query = worker_metadata::table
+      .filter(worker_metadata::service_id.eq(self.id))
+      .order(worker_metadata::name.asc());
+    let workers: Vec<WorkerMetadata> = workers_query.get_results(connection).unwrap_or_default();
+    Ok(workers)
   }
 }
 

--- a/templates/report.html.tera
+++ b/templates/report.html.tera
@@ -48,7 +48,7 @@
             <td class="right">{{global.todo}}</td>
           </tr>
           <tr class="info corpus-report-info">
-            <td class="left">In progress</td>
+            <td class="left"><a href="/workers/{{global.service_name_uri}}">In progress</a></td>
             <td class="right">{{global.queued_percent}}%</td>
             <td class="right">{{global.queued}}</td>
           </tr>

--- a/templates/workers.html.tera
+++ b/templates/workers.html.tera
@@ -1,0 +1,32 @@
+{% extends "layout" %} {% block content %}
+<div class="center">
+  <h1>Workers for {{global.service_name}}</h1>
+  <br>
+  <div>
+    <table id="service-report" class="table">
+      <thead>
+        <tr>
+          <th>Identity</th>
+          <th>First Seen</th>
+          <th>Dispatched To Last</th>
+          <th>Received From Last</th>
+          <th>Total Dispatched To</th>
+          <th>Total Received From</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for worker in workers %}
+        <tr>
+          <td>{{worker.name}}</td>
+          <td>{{worker.session_seen}}</td>
+          <td>{{worker.time_last_dispatch}}</td>
+          <td>{{worker.time_last_return}}</td>
+          <td>{{worker.total_dispatched}}</td>
+          <td>{{worker.total_returned}}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock content %}

--- a/templates/workers.html.tera
+++ b/templates/workers.html.tera
@@ -3,15 +3,15 @@
   <h1>Workers for {{global.service_name}}</h1>
   <br>
   <div>
-    <table id="service-report" class="table">
+    <table id="worker-report" class="table table-striped table-hover table-condensed">
       <thead>
         <tr>
-          <th>Identity</th>
-          <th>First Seen</th>
-          <th>Dispatched To Last</th>
-          <th>Received From Last</th>
-          <th>Total Dispatched To</th>
-          <th>Total Received From</th>
+          <th class="center">Identity</th>
+          <th class="center">First Seen</th>
+          <th class="center">Last Dispatch Time</th>
+          <th class="center">Last Returned Time</th>
+          <th class="center" width="90px;">Total Tasks Dispatched</th>
+          <th class="center" width="90px;">Total Tasks Returned</th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
Fixes #25

Requires breaking changes to `LaTeXML-Plugin-Cortex` and `Cortex`, as the sink interface now needs to also send over the worker identity.


