### PR TITLE
"loaded_file" info messages and report

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,4 @@ dotenv = "0.13"
 dotenv_codegen = "0.11"
 diesel = {version="=1.3.2", features = ["postgres"]}
 libxml = "0.2.2"
+lazy_static = "1.0.0"

--- a/bin/frontend.rs
+++ b/bin/frontend.rs
@@ -792,7 +792,7 @@ fn serve_report(
           "highlight".to_string(),
           aux_severity_highlight(&severity.clone().unwrap()).to_string(),
         );
-        template = if severity.is_some() && (severity.clone().unwrap() == "no_problem") {
+        template = if severity.is_some() && (severity.as_ref().unwrap() == "no_problem") {
           let entries = aux_task_report(
             &mut global,
             &corpus,
@@ -829,7 +829,7 @@ fn serve_report(
           aux_severity_highlight(&severity.clone().unwrap()).to_string(),
         );
         global.insert("category".to_string(), category.clone().unwrap());
-        if category.is_some() && (category.clone().unwrap() == "no_messages") {
+        if category.is_some() && (category.as_ref().unwrap() == "no_messages") {
           let entries = aux_task_report(
             &mut global,
             &corpus,
@@ -1322,7 +1322,7 @@ fn cache_worker() {
             // first cache the count for the next check:
             queued_cache.insert(key_base.clone(), queued_count);
             // each reported severity (fatal, warning, error)
-            for severity in &["invalid", "fatal", "error", "warning", "no_problem"] {
+            for severity in &["invalid", "fatal", "error", "warning", "no_problem", "info"] {
               // most importantly, DEL the key from Redis!
               let key_severity = key_base.clone() + "_" + severity;
               println!("[cache worker] DEL {:?}", key_severity);

--- a/bin/frontend.rs
+++ b/bin/frontend.rs
@@ -23,6 +23,8 @@ extern crate tokio_core;
 extern crate url;
 
 #[macro_use]
+extern crate lazy_static;
+#[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
 
@@ -59,6 +61,10 @@ use std::time::Duration;
 use cortex::backend::Backend;
 use cortex::models::{Corpus, Service, Task};
 use cortex::sysinfo;
+
+lazy_static! {
+  static ref STRIP_NAME_REGEX: Regex = Regex::new(r"/[^/]+$").unwrap();
+}
 
 pub struct CORS();
 
@@ -562,10 +568,7 @@ fn entry_fetch(
   let entry = task.entry;
   let zip_path = match service_name.as_str() {
     "import" => entry,
-    _ => {
-      let strip_name_regex = Regex::new(r"/[^/]+$").unwrap();
-      strip_name_regex.replace(&entry, "").to_string() + "/" + &service_name + ".zip"
-    },
+    _ => STRIP_NAME_REGEX.replace(&entry, "").to_string() + "/" + &service_name + ".zip",
   };
   if zip_path.is_empty() {
     Err(Redirect::to("/")) // TODO : Err(NotFound(format!("Service {:?} does not have a result for entry {:?}",

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -502,7 +502,7 @@ impl Backend {
     severity_opt: Option<String>,
     category_opt: Option<String>,
     what_opt: Option<String>,
-    all_messages: bool,
+    mut all_messages: bool,
     offset: i64,
     page_size: i64,
   ) -> Vec<HashMap<String, String>>
@@ -563,8 +563,12 @@ impl Backend {
 
         let log_table = match task_status {
           Some(ref ts) => ts.to_table(),
-          None => "log_infos".to_string(),
+          None => {
+            all_messages = true;
+            "log_infos".to_string()
+          },
         };
+
         let task_status_raw = task_status.unwrap_or(TaskStatus::Fatal).raw();
         let status_clause = if !all_messages {
           String::from("status=$3")

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -244,7 +244,9 @@ impl Backend {
         },
         None => {
           // All tasks in a certain status/severity
-          let status_to_rerun: i32 = TaskStatus::from_key(&severity).raw();
+          let status_to_rerun: i32 = TaskStatus::from_key(&severity)
+            .unwrap_or(TaskStatus::Fatal)
+            .raw();
           try!(
             update(tasks::table)
               .filter(corpus_id.eq(corpus.id))
@@ -515,12 +517,12 @@ impl Backend {
       let task_status = TaskStatus::from_key(&severity_name);
       // NoProblem report is a bit special, as it provides a simple list of entries - we assume no
       // logs of notability for this severity.
-      if task_status == TaskStatus::NoProblem {
+      if task_status == Some(TaskStatus::NoProblem) {
         let entry_rows: Vec<(String, i64)> = tasks::table
           .select((tasks::entry, tasks::id))
           .filter(service_id.eq(service.id))
           .filter(corpus_id.eq(corpus.id))
-          .filter(status.eq(task_status.raw()))
+          .filter(status.eq(task_status.unwrap().raw()))
           .order(tasks::entry.asc())
           .offset(offset as i64)
           .limit(page_size as i64)
@@ -559,17 +561,21 @@ impl Backend {
           .unwrap();
         let total_valid_count = total_count - invalid_count;
 
-        let log_table = task_status.to_table();
+        let log_table = match task_status {
+          Some(ref ts) => ts.to_table(),
+          None => "log_infos".to_string(),
+        };
+        let task_status_raw = task_status.unwrap_or(TaskStatus::Fatal).raw();
         let status_clause = if !all_messages {
           String::from("status=$3")
         } else {
           String::from("status < $3 and status > ") + &TaskStatus::Invalid.raw().to_string()
         };
         let bind_status = if !all_messages {
-          task_status.raw()
+          task_status_raw
         } else {
-          task_status.raw() + 1 // TODO: better would be a .prev() method or so, since this hardwires the assumption of
-                                // using adjacent negative integers
+          task_status_raw + 1 // TODO: better would be a .prev() method or so, since this hardwires the assumption of
+                              // using adjacent negative integers
         };
         match category_opt {
           None => {
@@ -594,7 +600,7 @@ impl Backend {
               tasks::table
                 .filter(service_id.eq(service.id))
                 .filter(corpus_id.eq(corpus.id))
-                .filter(status.eq(task_status.raw()))
+                .filter(status.eq(task_status_raw))
                 .count()
                 .get_result(&self.connection)
                 .unwrap_or(-1)
@@ -647,7 +653,7 @@ impl Backend {
               .bind::<BigInt, i64>(i64::from(service.id))
               .bind::<BigInt, i64>(i64::from(corpus.id))
               .bind::<BigInt, i64>(i64::from(bind_status))
-              .bind::<BigInt, i64>(i64::from(task_status.raw()));
+              .bind::<BigInt, i64>(i64::from(task_status_raw));
             let no_message_tasks: Vec<Task> = no_messages_query
               .get_results(&self.connection)
               .unwrap_or_default();

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -208,16 +208,17 @@ impl TaskStatus {
     }
   }
   /// Maps from the raw severity log values into the enumeration
-  pub fn from_key(key: &str) -> Self {
+  pub fn from_key(key: &str) -> Option<Self> {
     match key.to_lowercase().as_str() {
-      "no_problem" => TaskStatus::NoProblem,
-      "warning" => TaskStatus::Warning,
-      "error" => TaskStatus::Error,
-      "todo" => TaskStatus::TODO,
-      "invalid" => TaskStatus::Invalid,
-      "blocked" => TaskStatus::Blocked(-6),
-      "queued" => TaskStatus::Queued(1),
-      "fatal" | _ => TaskStatus::Fatal,
+      "no_problem" => Some(TaskStatus::NoProblem),
+      "warning" => Some(TaskStatus::Warning),
+      "error" => Some(TaskStatus::Error),
+      "todo" => Some(TaskStatus::TODO),
+      "invalid" => Some(TaskStatus::Invalid),
+      "blocked" => Some(TaskStatus::Blocked(-6)),
+      "queued" => Some(TaskStatus::Queued(1)),
+      "fatal" => Some(TaskStatus::Fatal),
+      _ => None,
     }
   }
   /// Returns all raw severity strings as a vector

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ extern crate regex;
 extern crate sys_info;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
+extern crate lazy_static;
 extern crate serde_json;
 extern crate tempfile;
 extern crate time;

--- a/templates/category-report.html.tera
+++ b/templates/category-report.html.tera
@@ -2,18 +2,19 @@
 <div class="center">
   <h1>"{{global.category}}" classes</h1>
 
-  {% if global.all_messages_true %}
+  {% if global.severity != "info" %} {% if global.all_messages_true %}
   <h5>All Tasks</h5>
   <h5>
-    <a href="/corpus/{{global.corpus_name_uri}}/{{global.service_name_uri}}/{{global.severity}}/{{global.category_uri}}?all=false">(Click here to switch to {{global.severity}} only)</a>
+    <a href="/corpus/{{global.corpus_name_uri}}/{{global.service_name_uri}}/{{global.severity}}/{{global.category_uri}}?all=false">(Click
+      here to switch to {{global.severity}} only)</a>
   </h5>
   {% else %}
   <h5>"{{global.severity}}" severity tasks</h5>
   <h5>
-    <a href="/corpus/{{global.corpus_name_uri}}/{{global.service_name_uri}}/{{global.severity}}/{{global.category_uri}}?all=true">(Click here to see this report for all tasks)</a>
+    <a href="/corpus/{{global.corpus_name_uri}}/{{global.service_name_uri}}/{{global.severity}}/{{global.category_uri}}?all=true">(Click
+      here to see this report for all tasks)</a>
   </h5>
-  {% endif %}
-
+  {% endif %} {% endif %}
   <br>
 
   <div class="row">

--- a/templates/report.html.tera
+++ b/templates/report.html.tera
@@ -69,6 +69,7 @@
           </tr>
         </tbody>
       </table>
+      <div><a href="/corpus/{{global.corpus_name_uri}}/{{global.service_name_uri}}/info">Explore Info-level messages</a></div>
     </div>
     <div class="col-md-4"></div>
   </div>

--- a/templates/severity-report.html.tera
+++ b/templates/severity-report.html.tera
@@ -1,8 +1,7 @@
 {% extends "layout" %} {% block content %}
 <div class="center">
   <h1>{{global.severity}} categories</h1>
-
-  {% if global.all_messages_true %}
+  {% if global.severity != "info" %} {% if global.all_messages_true %}
   <h5>All Tasks</h5>
   <h5>
     <a href="/corpus/{{global.corpus_name_uri}}/{{global.service_name_uri}}/{{global.severity}}?all=false">(Click here to
@@ -14,7 +13,7 @@
     <a href="/corpus/{{global.corpus_name_uri}}/{{global.service_name_uri}}/{{global.severity}}?all=true">(Click here to
       see this report for all tasks)</a>
   </h5>
-  {% endif %}
+  {% endif %} {% endif %}
 
   <br>
   <div class="row">


### PR DESCRIPTION
Following @bfirsh 's request to provide a full report of the dependencies used in arXiv, this PR introduces:
 *  a regex for parsing out the `(Loading /path/file ...` messages from latexml
 * an `info`-level report for exploring the new `loaded_file` category, as well as all other collected info messages
 * a few of fast optimizations - lazy_static for single initialization of regexes, a tighter loop in log parsing, dropping the status message from the info table since it's redundant to the main task severity.

It would require a full arXiv rerun to obtain the full report, which won't be too soon, but would already be interesting to try on the 08.2018 month, which should be released tomorrow (and added to the cortex deployment soon after).