### PR TITLE
Recover DB report from log files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015-2018 Deyan Ginev
+Copyright (c) 2015-2025 Deyan Ginev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bin/dispatcher.rs
+++ b/bin/dispatcher.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/bin/frontend.rs
+++ b/bin/frontend.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/examples/extend_corpora.rs
+++ b/examples/extend_corpora.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/examples/record_loading_info.rs
+++ b/examples/record_loading_info.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/examples/recover_log_reports.rs
+++ b/examples/recover_log_reports.rs
@@ -1,0 +1,98 @@
+use std::env;
+use std::thread;
+use std::time::Duration;
+use std::path::Path;
+
+use regex::Regex;
+use lazy_static::lazy_static;
+
+use diesel::*;
+
+use cortex::backend::Backend;
+use cortex::models::{Corpus, Service, Task};
+use cortex::helpers::{TaskStatus, generate_report};
+use cortex::schema::tasks;
+use cortex::schema::tasks::dsl::{corpus_id, service_id,status};
+
+lazy_static! {
+  static ref ENTRY_ZIP_NAME_REGEX: Regex =
+    Regex::new(r"[^/]+\.zip$").unwrap();
+}
+// use Archive::*;
+
+// Walks all TODO "status" entries of a corpus, unpacks+scans their cortex.log file, then
+// 1. uses conversion status to update "status" value in tasks
+// 2. uses log scanner to insert all log messages in log tables, same logic as in dispatcher
+//
+// Note: we are only recovering the "tex_to_html" service here
+fn main() {
+  // Read input arguments
+  let mut input_args = env::args();
+  let _ = input_args.next(); // skip process name
+  let corpus_path = match input_args.next() {
+    Some(path) => path,
+    None => {
+      eprintln!("-- Usage: recover_log_reports <corpus_path>");
+      std::process::exit(1);
+    },
+  };
+  let mut backend = Backend::default();
+  let corpus = Corpus::find_by_path(&corpus_path, &mut backend.connection)
+    .expect("Please provide a path to a registered corpus");
+  let service = Service::find_by_name("tex_to_html", &mut backend.connection)
+    .expect("DB connection failed: could not find tex_to_hml service");
+
+    let batch_size = 100;
+  // Fetch a batch of tasks for the given corpus and service
+  let mut offset = 0;
+  loop {
+    let batch : Vec<Task> = tasks::table
+      .filter(corpus_id.eq(corpus.id))
+      .filter(service_id.eq(service.id))
+      .filter(status.eq(TaskStatus::TODO.raw()))
+      .offset(offset)
+      .limit(batch_size)
+      .get_results(&mut backend.connection).expect("DB connection failed");
+    let batch_len = batch.len();
+    let mut batch_reports = Vec::new();
+    eprintln!("-- Processing {} tasks from offset {}", batch_len, offset);
+    for task in batch {
+      let html_entry = ENTRY_ZIP_NAME_REGEX.replace(&task.entry,"tex_to_html.zip").to_string();
+      let html_entry_path = Path::new(&html_entry);
+      if html_entry_path.exists() {
+        let report = generate_report(task, html_entry_path);
+        batch_reports.push(report);
+      } else {
+        eprintln!("-- Missing result file: {:?}", html_entry);
+      }
+    }
+    let mut success = false;
+    let reports_len : usize = batch_reports.iter().map(|r| r.messages.len()).sum();
+    if let Err(e) = backend.mark_done(&batch_reports) {
+      eprintln!("-- mark_done attempt failed: {e:?}");
+      // DB persist failed, retry
+      let mut retries = 0;
+      while retries < 3 {
+        thread::sleep(Duration::new(2, 0)); // wait 2 seconds before retrying, in case this is latency related
+        retries += 1;
+        match backend.mark_done(&batch_reports) {
+          Ok(_) => {
+            success = true;
+            break;
+          },
+          Err(e) => eprintln!("-- mark_done retry failed: {e:?}"),
+        };
+      }
+    } else {
+      success = true;
+    }
+    if success {
+      eprintln!("-- Successfully saved {} reports for {} tasks", reports_len, batch_len);
+    }
+    if batch_len < batch_size as usize {
+      break; // No more tasks to process
+    }
+    offset += batch_size;
+  }
+}
+

--- a/examples/register_service.rs
+++ b/examples/register_service.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/examples/sandbox_arxiv.rs
+++ b/examples/sandbox_arxiv.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/examples/tex_to_html_import.rs
+++ b/examples/tex_to_html_import.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/examples/tex_to_html_worker.rs
+++ b/examples/tex_to_html_worker.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/src/concerns.rs
+++ b/src/concerns.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/src/dispatcher/manager.rs
+++ b/src/dispatcher/manager.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/src/dispatcher/ventilator.rs
+++ b/src/dispatcher/ventilator.rs
@@ -57,6 +57,9 @@ impl Ventilator {
       ventilator.recv(&mut identity, 0)?;
       ventilator.recv(&mut msg, 0)?;
       let service_name = msg.as_str().unwrap_or_default().to_string();
+      if service_name.is_empty() {
+        continue; // Skip empty service names, they are not valid
+      }
       let identity_str = identity.as_str().unwrap_or_default().to_string();
       // println!("Task requested for service: {}", service_name.clone());
       let request_time = time::get_time();

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/src/importer.rs
+++ b/src/importer.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/tests/backend_test.rs
+++ b/tests/backend_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/tests/echo_roundtrip_test.rs
+++ b/tests/echo_roundtrip_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/tests/importer_test.rs
+++ b/tests/importer_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.

--- a/tests/tex_to_html_test.rs
+++ b/tests/tex_to_html_test.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Deyan Ginev. See the LICENSE
+// Copyright 2015-2025 Deyan Ginev. See the LICENSE
 // file at the top-level directory of this distribution.
 //
 // Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.


### PR DESCRIPTION
This PR contains a recovery script that repopulates the DB for a registered corpus from the available files on disk, only consulting tasks marked "todo".

The new example is currently used to recover the entire arXiv log collection, trackable here:
https://corpora.mathweb.org/corpus/arxmliv/tex%5Fto%5Fhtml

There is a separate change to the ventilator module attempting to detect ZMQ messaging failures. Possibly due to recent version updates we have had some logged cases of empty messages getting received, and then getting a parity bug where the identity and task name messages get swapped. 

It also updates an outdated date that has no bearing to anything.