### PR TITLE
Recovery from malformed task request

### DIFF
--- a/src/backend/reports.rs
+++ b/src/backend/reports.rs
@@ -153,17 +153,11 @@ pub(crate) fn task_report(
       };
 
       let task_status_raw = task_status.unwrap_or(TaskStatus::NoProblem).raw();
-      let status_clause = if !all_messages {
-        String::from("status=$3 ")
+      let (status_clause,bind_status) = if !all_messages {
+        (String::from("status=$3 "), task_status_raw)
       } else {
-        String::from("status < $3 and status > ") + &TaskStatus::Invalid.raw().to_string()
-      };
-      let bind_status = if !all_messages {
-        task_status_raw
-      } else {
-        task_status_raw + 1 // TODO: better would be a .prev() method or so, since this hardwires
-                            // the assumption of using adjacent negative
-                            // integers
+        (String::from("status < $3 and status > ") + &TaskStatus::Invalid.raw().to_string(),
+          0) // all completed tasks are negative integers, so 0 is a safe upper bound
       };
       match category_opt {
         None => {

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -150,7 +150,7 @@ pub fn get_service<S: ::std::hash::BuildHasher>(
     .expect("Failed to obtain Mutex lock in get_service");
   let service = services.get(service_name);
   match service {
-    None => None, // TODO: Handle errors
+    None => None, // TODO: Should we panic? Can we recover?
     Some(service) => service.clone(),
   }
 }


### PR DESCRIPTION
It is hard to isolate the failure mode. It appears very rare and has to do with subtleties in the way zmq receives the message pieces, but it is almost impossible to diagnose without having a method to reproduce it.