### PR TITLE
Bump rand 0.8 → 0.10.1 (supersedes #325, #358)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -363,6 +363,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,7 +515,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pericortex",
- "rand 0.8.6",
+ "rand 0.10.1",
  "regex",
  "rocket",
  "rocket_dyn_templates",
@@ -530,6 +541,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -940,7 +960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1189,6 +1209,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1647,7 +1668,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2391,6 +2412,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,6 +2459,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -2648,7 +2686,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2832,7 +2870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2843,7 +2881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3047,7 +3085,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3692,7 +3730,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ regex = "1.12.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 glob = "0.3.3"
-rand = "0.8.0"
+rand = "0.10.1"
 tempfile = "3"
 rocket = { version = "0.5.1", features = ["json"] }
 rocket_dyn_templates = { version = "0.2.0", features = ["tera"] }

--- a/src/backend/tasks_aggregate.rs
+++ b/src/backend/tasks_aggregate.rs
@@ -4,7 +4,7 @@ use crate::models::{Service, Task};
 use crate::schema::tasks;
 use diesel::result::Error;
 use diesel::*;
-use rand::{Rng, thread_rng};
+use rand::RngExt;
 
 pub(crate) fn fetch_tasks(
   connection: &mut PgConnection,
@@ -12,8 +12,8 @@ pub(crate) fn fetch_tasks(
   queue_size: usize,
 ) -> Result<Vec<Task>, Error> {
   use crate::schema::tasks::dsl::{service_id, status};
-  let mut rng = thread_rng();
-  let mark: u16 = 1 + rng.r#gen::<u16>();
+  let mut rng = rand::rng();
+  let mark: u16 = 1 + rng.random::<u16>();
 
   let mut marked_tasks: Vec<Task> = Vec::new();
   connection.transaction::<(), Error, _>(|t_connection| {

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -14,8 +14,8 @@ use std::path::Path;
 
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
-use rand::distributions::Alphanumeric;
-use rand::{Rng, thread_rng};
+use rand::RngExt;
+use rand::distr::Alphanumeric;
 use serde::Serialize;
 
 use crate::config::{CortexConfig, to_persisted_toml};
@@ -206,7 +206,7 @@ pub struct SetTokenOutcome {
 /// lightweight scheme — see `docs/archive/AAA_DESIGN.md`); hashing-at-rest is a documented later
 /// step.
 pub fn generate_token() -> String {
-  thread_rng()
+  rand::rng()
     .sample_iter(&Alphanumeric)
     .take(32)
     .map(char::from)

--- a/src/frontend/webauthn.rs
+++ b/src/frontend/webauthn.rs
@@ -21,8 +21,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use rand::distributions::Alphanumeric;
-use rand::{Rng, thread_rng};
+use rand::RngExt;
+use rand::distr::Alphanumeric;
 use rocket::http::{Cookie, CookieJar, SameSite, Status};
 use rocket::response::Redirect;
 use rocket::serde::json::Json;
@@ -113,7 +113,7 @@ impl CeremonyStore {
 
   /// Stores a ceremony, pruning expired entries, and returns its random id (for the cookie).
   pub fn put(&self, ceremony: Ceremony) -> String {
-    let id: String = thread_rng()
+    let id: String = rand::rng()
       .sample_iter(&Alphanumeric)
       .take(32)
       .map(char::from)

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -6,7 +6,7 @@
 // except according to those terms.
 
 //! Helper structures and methods for Task
-use rand::{Rng, thread_rng};
+use rand::RngExt;
 use regex::Regex;
 use std::fs::File;
 use std::io;
@@ -640,15 +640,15 @@ pub fn utf_truncate(input: &mut String, maxsize: usize) {
 
 /// Generate a random integer useful for temporary DB marks
 pub fn random_mark() -> i32 {
-  let mut rng = thread_rng();
-  let mark_rng: u16 = rng.r#gen();
+  let mut rng = rand::rng();
+  let mark_rng: u16 = rng.random();
   i32::from(mark_rng)
 }
 
 /// Helper for generating a random i32 in a range, to avoid loading the rng crate + boilerplate
 pub fn rand_in_range(from: u16, to: u16) -> u16 {
-  let mut rng = thread_rng();
-  let mark_rng: u16 = rng.gen_range(from..=to);
+  let mut rng = rand::rng();
+  let mark_rng: u16 = rng.random_range(from..=to);
   mark_rng
 }
 

--- a/src/models/session.rs
+++ b/src/models/session.rs
@@ -13,8 +13,8 @@
 use chrono::{Duration, NaiveDateTime, Utc};
 use diesel::prelude::*;
 use diesel::result::Error;
-use rand::distributions::Alphanumeric;
-use rand::{Rng, thread_rng};
+use rand::RngExt;
+use rand::distr::Alphanumeric;
 
 use crate::schema::sessions;
 
@@ -54,7 +54,7 @@ impl Session {
   pub fn open(connection: &mut PgConnection, owner: &str, method: &str) -> Result<String, Error> {
     let _ = Self::prune_expired(connection);
     // 48 url-safe chars (~285 bits) — an unguessable bearer; the security rests on this randomness.
-    let id: String = thread_rng()
+    let id: String = rand::rng()
       .sample_iter(&Alphanumeric)
       .take(48)
       .map(char::from)

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -6,8 +6,7 @@
 // except according to those terms.
 
 //! Worker for performing corpus imports, when served as "init" tasks by the `CorTeX` dispatcher
-use rand::seq::SliceRandom;
-use rand::thread_rng;
+use rand::seq::IndexedRandom;
 use std::borrow::Cow;
 use std::error::Error;
 use std::fs::File;
@@ -111,7 +110,7 @@ impl Worker for InitWorker {
 
   fn start(&mut self, limit: Option<usize>) -> Result<(), Box<dyn Error>> {
     let mut work_counter = 0;
-    let mut rng = thread_rng();
+    let mut rng = rand::rng();
     // Connect to a task ventilator
     let context_source = Context::new();
     let source = context_source.socket(zmq::DEALER).unwrap();
@@ -172,7 +171,7 @@ mod tests {
   #[test]
   fn configured_identity_is_honored_verbatim() {
     // An operator-set identity is used as-is, giving a stable worker_metadata key (W-3).
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     assert_eq!(
       resolve_worker_identity("arxiv-host3:init:1", &mut rng),
       "arxiv-host3:init:1"
@@ -181,7 +180,7 @@ mod tests {
 
   #[test]
   fn empty_identity_falls_back_to_a_random_handle() {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let id = resolve_worker_identity("", &mut rng);
     assert_eq!(id.len(), 19, "preserves the historical 19-char length");
     assert!(


### PR DESCRIPTION
Upgrades the direct **`rand`** dependency from `0.8.0` to **`0.10.1`** (latest), and confirms **`time`** needs no change. This supersedes the two stale dependabot PRs.

## `rand` 0.8 → 0.10.1
Dependabot only bumped the version (#358); the 0.8→0.10 jump crosses two breaking majors, so this migrates the API. Every change is a **pure rename — output semantics are unchanged** (verified against the crate sources):

| 0.8 | 0.10 |
|---|---|
| `rand::thread_rng()` | `rand::rng()` (same `ThreadRng` CSPRNG) |
| `use rand::Rng` (ext. methods) | `use rand::RngExt` |
| `rng.gen()` / `gen_range()` | `rng.random()` / `random_range()` |
| `rand::distributions::Alphanumeric` | `rand::distr::Alphanumeric` |
| `rand::seq::SliceRandom::choose` | `rand::seq::IndexedRandom::choose` |

- The `&mut impl rand::Rng` bound in `worker.rs` is unchanged: in 0.10 `rand::Rng` is the **core** trait (formerly `RngCore`), which is exactly what `choose` requires.
- **Security paths unaffected:** `Alphanumeric` is byte-identical (62-char `A-Z a-z 0-9`, same bitshift+rejection algorithm) and `ThreadRng` is still a `CryptoRng`, so the documented ~190-bit (token) / ~285-bit (session id) entropy claims in `bootstrap.rs` / `session.rs` / `webauthn.rs` still hold.

Files: `helpers.rs`, `backend/tasks_aggregate.rs`, `worker.rs`, `frontend/webauthn.rs`, `bootstrap.rs`, `models/session.rs` (+ `Cargo.toml`/`Cargo.lock`).

## `time` — nothing to do
PR #325 (bump `time 0.1.45 → 0.3.41`) is **obsolete**: `time` is a transitive-only dependency already at **`0.3.49`** (newer than the PR's target), and the old direct `time 0.1.45` it targeted was removed in the v0.5.0 sprint.

## Verification
- `cargo build` ✅ · `cargo clippy --all --workspace` — 0 warnings ✅ · `cargo fmt --check` ✅
- Full `cargo test` suite green (run on PostgreSQL 18, the project floor), including the rand-touching unit tests (worker identity, token generation) and DB-backed session/auth tests.

Supersedes and closes #325 and #358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)