### PR TITLE
feat(dispatcher): run-completion-on-drain — close a run when its work is exhausted

### DIFF
--- a/examples/dispatcher_bench.rs
+++ b/examples/dispatcher_bench.rs
@@ -14,7 +14,8 @@
 // Measures (perf):   wall-clock drain time, tasks/s, tasks/s/worker, sink-write throughput (MB/s).
 // Asserts (robust):  every task reaches a terminal status (no loss); none left TODO/Queued; the
 //                    status distribution matches the controlled payload (the parse path is
-// correct);                    worker_metadata recorded every dispatch + return.
+// correct);                    worker_metadata recorded every dispatch + return; and the open
+//                    historical run is CLOSED on drain (run-completion-on-drain sets end_time).
 //
 // Env knobs: BENCH_TASKS (default 20000), BENCH_WORKERS (default 4), BENCH_PAYLOAD_KB (default 8,
 // the source/result archive size), BENCH_DEADLINE_S (default 180), BENCH_JSON=1 (emit a one-line
@@ -34,10 +35,10 @@ use cortex::backend;
 use cortex::backend::test_db_address;
 use cortex::dispatcher::manager::TaskManager;
 use cortex::helpers::TaskStatus;
-use cortex::models::{Corpus, NewCorpus, NewService, NewTask, Service};
+use cortex::models::{Corpus, NewCorpus, NewHistoricalRun, NewService, NewTask, Service};
 use pericortex::worker::{EchoWorker, Worker};
 
-use cortex::schema::{corpora, services, tasks, worker_metadata};
+use cortex::schema::{corpora, historical_runs, services, tasks, worker_metadata};
 use diesel::dsl::sql;
 use diesel::prelude::*;
 use diesel::sql_types::BigInt;
@@ -86,6 +87,20 @@ fn completed_count(conn: &mut diesel::PgConnection, corpus_id: i32, service_id: 
     .count()
     .get_result(conn)
     .unwrap_or(0)
+}
+
+/// Whether this pair's historical run has been **closed** (its `end_time` is set). The bench opens
+/// exactly one run for the freshly-minted `(corpus, service)` pair, so a non-null `end_time` means
+/// run-completion-on-drain fired: the finalize thread observed the queue drain and closed the run.
+fn run_closed(conn: &mut diesel::PgConnection, corpus_id: i32, service_id: i32) -> bool {
+  historical_runs::table
+    .filter(historical_runs::corpus_id.eq(corpus_id))
+    .filter(historical_runs::service_id.eq(service_id))
+    .filter(historical_runs::end_time.is_not_null())
+    .count()
+    .get_result::<i64>(conn)
+    .unwrap_or(0)
+    > 0
 }
 
 /// A **saboteur**: a raw ZMQ `DEALER` that leases `strand` tasks from the ventilator and then dies
@@ -227,6 +242,18 @@ fn main() {
       .expect("bulk insert tasks");
   }
 
+  // Open a historical run for this pair, exactly as a rerun would — so the drain below can assert
+  // run-completion-on-drain closes it (sets `end_time`) once the queue empties. The fresh corpus +
+  // service ids isolate it from any prior bench run, so it is the only run for this pair.
+  backend
+    .add(&NewHistoricalRun {
+      corpus_id: corpus.id,
+      service_id: service.id,
+      description: String::from("dispatcher_bench run"),
+      owner: String::from("dispatcher_bench"),
+    })
+    .expect("open historical run");
+
   println!(
     "[{label}] staged {n_tasks} TODO tasks ({payload_kb}KB each), {n_workers} worker(s); draining..."
   );
@@ -284,6 +311,23 @@ fn main() {
   let elapsed = start.elapsed();
   let drained = completed as usize >= n_tasks;
 
+  // --- Run-completion-on-drain gate ------------------------------------------------------------
+  // Once the queue drains, the finalize thread's idle tick must CLOSE the open historical run
+  // (freeze tallies + set `end_time`) rather than leave it "ongoing" until the next rerun. The
+  // close fires on the ~1s idle Timeout after the last result lands, so poll briefly past the
+  // task-drain rather than reading once.
+  let mut run_closed_on_drain = false;
+  if drained {
+    let close_deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < close_deadline {
+      if run_closed(&mut backend.connection, corpus.id, service.id) {
+        run_closed_on_drain = true;
+        break;
+      }
+      thread::sleep(Duration::from_millis(200));
+    }
+  }
+
   // --- Robustness audit ------------------------------------------------------------------------
   let no_problem = status_count(
     &mut backend.connection,
@@ -339,6 +383,14 @@ fn main() {
   println!("transfer                : {mbps:.0} MB/s (source+result)");
   println!("status: NoProblem {no_problem} · TODO {still_todo} · Queued {still_queued}");
   println!("metadata: dispatched {dispatched} · returned {returned}");
+  println!(
+    "run-completion          : {}",
+    if run_closed_on_drain {
+      "closed on drain ✓"
+    } else {
+      "STILL OPEN"
+    }
+  );
 
   // Correctness gates — a perf change that loses/mis-statuses work must FAIL here.
   let mut failures: Vec<String> = Vec::new();
@@ -358,12 +410,18 @@ fn main() {
       "status distribution wrong: expected {n_tasks} NoProblem, got {no_problem} (parse-path regression?)"
     ));
   }
+  if drained && !run_closed_on_drain {
+    failures.push(
+      "run-completion-on-drain: historical run still open (end_time NULL) after the queue drained"
+        .to_string(),
+    );
+  }
   // NB: worker_metadata is intentionally best-effort (the D-1 writer drops under saturation), so
   // its totals are reported but never asserted — they would flake.
 
   if json {
     println!(
-      "JSON {{\"label\":\"{label}\",\"workers\":{n_workers},\"payload_kb\":{payload_kb},\"tasks\":{n_tasks},\"drained\":{drained},\"secs\":{secs:.3},\"tasks_per_s\":{rate:.1},\"mb_per_s\":{mbps:.1},\"no_problem\":{no_problem},\"ok\":{}}}",
+      "JSON {{\"label\":\"{label}\",\"workers\":{n_workers},\"payload_kb\":{payload_kb},\"tasks\":{n_tasks},\"drained\":{drained},\"secs\":{secs:.3},\"tasks_per_s\":{rate:.1},\"mb_per_s\":{mbps:.1},\"no_problem\":{no_problem},\"run_closed_on_drain\":{run_closed_on_drain},\"ok\":{}}}",
       failures.is_empty()
     );
   }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -308,6 +308,18 @@ impl Backend {
   pub fn invalidate_report_cache(&mut self, corpus_id: i32, service_id: i32) -> Result<(), Error> {
     rollup::invalidate_scope(&mut self.connection, corpus_id, service_id)
   }
+  /// Run-completion-on-drain: close the `(corpus, service)` pair's open historical run iff its work
+  /// is exhausted (every task terminal). Delegates to
+  /// [`HistoricalRun::complete_if_drained`](crate::models::HistoricalRun::complete_if_drained);
+  /// returns `true` iff a run was closed. Called per touched scope from the dispatcher's finalize
+  /// loop when the queue idles, so a finished run is closed at once rather than at the next rerun.
+  pub fn complete_run_if_drained(
+    &mut self,
+    corpus_id: i32,
+    service_id: i32,
+  ) -> Result<bool, Error> {
+    crate::models::HistoricalRun::complete_if_drained(corpus_id, service_id, &mut self.connection)
+  }
   /// Category-grain report for `(corpus, service, severity)`, read from the `report_summary`
   /// rollup, windowed to `[offset, offset + limit)` (ordered by descending task count).
   pub fn category_rollup(

--- a/src/dispatcher/finalize.rs
+++ b/src/dispatcher/finalize.rs
@@ -116,23 +116,23 @@ impl Finalize {
           );
           // Long runs may never idle, so bound report staleness with a periodic refresh.
           if last_report_refresh.elapsed() >= report_refresh_interval() {
-            invalidate_touched(&mut backend, &mut touched);
+            settle_touched(&mut backend, &mut touched);
             reports_dirty = false;
             last_report_refresh = Instant::now();
           }
           if disconnected {
             // Producers vanished mid-batch: we persisted what we had; make it visible and stop.
             if reports_dirty {
-              invalidate_touched(&mut backend, &mut touched);
+              settle_touched(&mut backend, &mut touched);
             }
             break;
           }
         },
         Err(RecvTimeoutError::Timeout) => {
-          // The queue just drained: recompute the rollup so finished work shows up in reports
-          // immediately, then keep waiting.
+          // The queue just idled: close any historical run whose work has drained, recompute the
+          // rollup so finished work shows up in reports immediately, then keep waiting.
           if reports_dirty {
-            invalidate_touched(&mut backend, &mut touched);
+            settle_touched(&mut backend, &mut touched);
             reports_dirty = false;
             last_report_refresh = Instant::now();
           }
@@ -140,13 +140,41 @@ impl Finalize {
         Err(RecvTimeoutError::Disconnected) => {
           // Every producer (sink + ventilator) has gone — clean shutdown. Flush and stop.
           if reports_dirty {
-            invalidate_touched(&mut backend, &mut touched);
+            settle_touched(&mut backend, &mut touched);
           }
           break;
         },
       }
     }
     Ok(())
+  }
+}
+
+/// On drain/idle, settle the `(corpus, service)` scopes touched since the last tick: first close
+/// any historical runs whose work has drained (run-completion-on-drain), then drop those scopes'
+/// cached report grains so the next report view repopulates. Order matters — closing the run
+/// freezes its tallies, and we invalidate the report cache *after* so the next view reads the
+/// frozen, completed run rather than the stale open one. Drains `touched`.
+fn settle_touched(backend: &mut backend::Backend, touched: &mut HashSet<(i32, i32)>) {
+  complete_drained_runs(backend, touched);
+  invalidate_touched(backend, touched);
+}
+
+/// Run-completion-on-drain: for each scope we've persisted results for since the last tick, close
+/// its open historical run if the pair's work is now exhausted (no task left `TODO`, `Queued`, or
+/// `Blocked`). This fires the "run ended" event the instant the queue drains, instead of lazily
+/// when the next rerun starts — so a finished run stops showing as "ongoing" right away. Read-only
+/// over `touched` (the following [`invalidate_touched`] drains it). A per-scope failure is logged
+/// and skipped so the finalize thread keeps running; the next idle/periodic tick retries.
+fn complete_drained_runs(backend: &mut backend::Backend, touched: &HashSet<(i32, i32)>) {
+  for &(corpus_id, service_id) in touched {
+    match backend.complete_run_if_drained(corpus_id, service_id) {
+      Ok(true) => debug!(corpus_id, service_id, "finalize: closed drained run"),
+      Ok(false) => {},
+      Err(e) => warn!(
+        "finalize: run-completion check ({corpus_id}, {service_id}) failed (non-fatal): {e:?}"
+      ),
+    }
   }
 }
 

--- a/src/models/historical_runs.rs
+++ b/src/models/historical_runs.rs
@@ -277,6 +277,58 @@ impl HistoricalRun {
     Ok(())
   }
 
+  /// **Run-completion-on-drain.** Close the open historical run for a `(corpus, service)` pair the
+  /// moment its work is exhausted — every task has reached a terminal severity, with nothing left
+  /// `TODO`, in-flight (`Queued`), or `Blocked` on a prerequisite. Freezes the run's tallies and
+  /// sets `end_time` (via [`Self::mark_completed`]), so a finished run stops reading as "ongoing"
+  /// *immediately*, instead of only when the next rerun supersedes it (the lazy
+  /// [`mark_new_run`](crate::backend::mark_new_run) path that left a run "ongoing" until the very
+  /// minute the next run started). Returns `true` iff a run was actually closed.
+  ///
+  /// Idempotent and safe to call repeatedly from the dispatcher's finalize loop: a no-op when work
+  /// still remains, when there is no open run (already closed, or never started), or for the
+  /// bookkeeping services `init` (1) / `import` (2) — those are not user-facing conversion runs and
+  /// are skipped.
+  pub fn complete_if_drained(
+    corpus: i32,
+    service: i32,
+    connection: &mut PgConnection,
+  ) -> Result<bool, Error> {
+    use crate::schema::historical_runs::dsl::{corpus_id, end_time, service_id};
+    use crate::schema::tasks;
+    // `init` (1) / `import` (2) are bookkeeping services, not conversion runs — no run to close.
+    if service <= 2 {
+      return Ok(false);
+    }
+    // Unfinished = anything OUTSIDE the terminal severity band [-5, -1]: `TODO` (0) and `Queued`
+    // (> 0) still to run, plus `Blocked` (< -5) gated on a prerequisite service. While any of these
+    // remain the run can still produce a result, so it is NOT drained. (Mirror of the raw status
+    // mapping in `TaskStatus::from_raw`.)
+    let unfinished: i64 = tasks::table
+      .filter(tasks::corpus_id.eq(corpus))
+      .filter(tasks::service_id.eq(service))
+      .filter(tasks::status.ge(0).or(tasks::status.lt(-5)))
+      .count()
+      .get_result(connection)?;
+    if unfinished > 0 {
+      return Ok(false);
+    }
+    // Drained: freeze + close the pair's open run, if one is still open.
+    let open: Option<HistoricalRun> = historical_runs::table
+      .filter(corpus_id.eq(corpus))
+      .filter(service_id.eq(service))
+      .filter(end_time.is_null())
+      .first(connection)
+      .optional()?;
+    match open {
+      Some(run) => {
+        run.mark_completed(connection)?;
+        Ok(true)
+      },
+      None => Ok(false),
+    }
+  }
+
   /// Returns this run with its per-severity tallies reflecting **live** task state *when the run is
   /// still open* (`end_time` is `None`). A run only freezes its tallies at [`Self::mark_completed`]
   /// (i.e. when the next run supersedes it), so an open run's stored tallies are all zero;

--- a/src/models/historical_runs.rs
+++ b/src/models/historical_runs.rs
@@ -255,26 +255,40 @@ impl HistoricalRun {
       .optional()
   }
 
-  /// Mark this historical run as completed, by setting `end_time` to the current time.
-  pub fn mark_completed(&self, connection: &mut PgConnection) -> Result<(), Error> {
+  /// Mark this historical run as completed: freeze its live tallies and set `end_time`, as an
+  /// **atomic compare-and-set** (`WHERE id = ? AND end_time IS NULL`). Exactly one caller can ever
+  /// close a given run — even under duplicate finalize passes (a re-tried last task that lands
+  /// twice) or, hypothetically, concurrent writers — because the open-row predicate lives in the
+  /// UPDATE itself, not in a separate read. Returns `true` iff **this** call performed the close
+  /// (the UPDATE matched the still-open row); `false` if the run was already closed (a no-op). That
+  /// `true` is the safe edge to hang any run-completion side effect on: it can never double-fire.
+  pub fn mark_completed(&self, connection: &mut PgConnection) -> Result<bool, Error> {
     use diesel::dsl::now;
-    if self.end_time.is_none() {
-      // Freeze the current statistics for this run, then close it.
-      let t = live_tally_fields(connection, self.corpus_id, self.service_id);
-      update(self)
-        .set((
-          historical_runs::end_time.eq(now),
-          historical_runs::total.eq(t.total),
-          historical_runs::in_progress.eq(t.in_progress),
-          historical_runs::invalid.eq(t.invalid),
-          historical_runs::no_problem.eq(t.no_problem),
-          historical_runs::warning.eq(t.warning),
-          historical_runs::error.eq(t.error),
-          historical_runs::fatal.eq(t.fatal),
-        ))
-        .execute(connection)?;
+    // Fast path: a run we already know is closed needs no tally recompute. The atomic UPDATE below
+    // is the real guard — this only skips wasted work in the already-closed case.
+    if self.end_time.is_some() {
+      return Ok(false);
     }
-    Ok(())
+    // Freeze the current statistics, then close — but the `end_time IS NULL` filter means a racing
+    // (or duplicate) close matches zero rows and is a clean no-op, never a re-mark.
+    let t = live_tally_fields(connection, self.corpus_id, self.service_id);
+    let rows = update(
+      historical_runs::table
+        .filter(historical_runs::id.eq(self.id))
+        .filter(historical_runs::end_time.is_null()),
+    )
+    .set((
+      historical_runs::end_time.eq(now),
+      historical_runs::total.eq(t.total),
+      historical_runs::in_progress.eq(t.in_progress),
+      historical_runs::invalid.eq(t.invalid),
+      historical_runs::no_problem.eq(t.no_problem),
+      historical_runs::warning.eq(t.warning),
+      historical_runs::error.eq(t.error),
+      historical_runs::fatal.eq(t.fatal),
+    ))
+    .execute(connection)?;
+    Ok(rows == 1)
   }
 
   /// **Run-completion-on-drain.** Close the open historical run for a `(corpus, service)` pair the
@@ -320,11 +334,11 @@ impl HistoricalRun {
       .filter(end_time.is_null())
       .first(connection)
       .optional()?;
+    // `mark_completed` is the atomic compare-and-set: it returns `true` only if THIS call closed
+    // the run, so a duplicate drain pass (or a racing writer) that finds the row already closed
+    // propagates as `false` here — never a second completion.
     match open {
-      Some(run) => {
-        run.mark_completed(connection)?;
-        Ok(true)
-      },
+      Some(run) => run.mark_completed(connection),
       None => Ok(false),
     }
   }

--- a/tests/runs_test.rs
+++ b/tests/runs_test.rs
@@ -12,7 +12,7 @@ use chrono::{NaiveDate, NaiveDateTime};
 use cortex::backend::{self, test_db_address};
 use cortex::frontend::server::mount_api_with;
 use cortex::helpers::TaskStatus;
-use cortex::models::{Corpus, NewCorpus, NewService, NewTask, Service};
+use cortex::models::{Corpus, HistoricalRun, NewCorpus, NewService, NewTask, Service};
 use cortex::schema::{corpora, historical_runs, historical_tasks, services, tasks};
 use diesel::prelude::*;
 use rocket::http::{ContentType, Status};
@@ -182,6 +182,192 @@ fn history_chart_escapes_script_breakout_in_a_description(client: &Client) {
     .ok();
 }
 
+/// Run-completion-on-drain at the model boundary (`HistoricalRun::complete_if_drained`, what the
+/// dispatcher's finalize loop calls on idle). It must close the open run for a `(corpus, service)`
+/// pair EXACTLY when its work is exhausted: never while a `TODO`/`Queued`/`Blocked` task could
+/// still produce a result, never for the bookkeeping services (`init`/`import`), and idempotently —
+/// freezing the run's final tallies as it closes.
+fn run_completion_on_drain_closes_only_a_fully_drained_run() {
+  let mut backend = backend::testdb();
+  let corpus_name = "drain_complete_corpus";
+  let service_name = "drain_complete_svc";
+  if let Ok(existing) = Corpus::find_by_name(corpus_name, &mut backend.connection) {
+    diesel::delete(historical_runs::table.filter(historical_runs::corpus_id.eq(existing.id)))
+      .execute(&mut backend.connection)
+      .ok();
+    diesel::delete(tasks::table.filter(tasks::corpus_id.eq(existing.id)))
+      .execute(&mut backend.connection)
+      .ok();
+    diesel::delete(corpora::table.filter(corpora::id.eq(existing.id)))
+      .execute(&mut backend.connection)
+      .ok();
+  }
+  diesel::delete(services::table.filter(services::name.eq(service_name)))
+    .execute(&mut backend.connection)
+    .ok();
+  backend
+    .add(&NewCorpus {
+      name: corpus_name.to_string(),
+      path: "/tmp/drain-complete".to_string(),
+      complex: true,
+      description: String::new(),
+    })
+    .expect("corpus");
+  let corpus = Corpus::find_by_name(corpus_name, &mut backend.connection).expect("corpus");
+  backend
+    .add(&NewService {
+      name: service_name.to_string(),
+      version: 0.1,
+      inputformat: "tex".to_string(),
+      outputformat: "html".to_string(),
+      inputconverter: Some("import".to_string()),
+      complex: true,
+      description: String::from("drain-completion service"),
+    })
+    .expect("service");
+  let service = Service::find_by_name(service_name, &mut backend.connection).expect("service");
+
+  // Open a run, as a rerun would.
+  backend
+    .mark_new_run(&corpus, &service, "tester".into(), "drain run".into())
+    .expect("open run");
+
+  // Seed a mixed distribution: 2 NoProblem + 1 Error are terminal; 1 TODO + 1 Blocked are NOT —
+  // either alone must keep the run open.
+  for i in 0..2 {
+    add_task(
+      &mut backend.connection,
+      &format!("/tmp/drain-complete/ok{i}.zip"),
+      service.id,
+      corpus.id,
+      TaskStatus::NoProblem.raw(),
+    );
+  }
+  add_task(
+    &mut backend.connection,
+    "/tmp/drain-complete/err.zip",
+    service.id,
+    corpus.id,
+    TaskStatus::Error.raw(),
+  );
+  let todo_id = add_task(
+    &mut backend.connection,
+    "/tmp/drain-complete/todo.zip",
+    service.id,
+    corpus.id,
+    TaskStatus::TODO.raw(),
+  );
+  // Blocked = a status below the terminal band (< -5), gated on a prerequisite service.
+  let blocked_id = add_task(
+    &mut backend.connection,
+    "/tmp/drain-complete/blocked.zip",
+    service.id,
+    corpus.id,
+    TaskStatus::Blocked(-6).raw(),
+  );
+
+  // (A) TODO + Blocked present → NOT drained.
+  let closed = HistoricalRun::complete_if_drained(corpus.id, service.id, &mut backend.connection)
+    .expect("drain check A");
+  assert!(!closed, "a run with a TODO + a Blocked task is not drained");
+  assert!(
+    HistoricalRun::find_current(&corpus, &service, &mut backend.connection)
+      .expect("current A")
+      .is_some(),
+    "the run is still open"
+  );
+
+  // (B) Clear the TODO; the lone Blocked task must still hold the run open (the `status < -5`
+  // branch — a run gated on a prerequisite is not finished).
+  diesel::update(tasks::table.filter(tasks::id.eq(todo_id)))
+    .set(tasks::status.eq(TaskStatus::NoProblem.raw()))
+    .execute(&mut backend.connection)
+    .expect("clear todo");
+  let closed = HistoricalRun::complete_if_drained(corpus.id, service.id, &mut backend.connection)
+    .expect("drain check B");
+  assert!(!closed, "a lone Blocked task still keeps the run open");
+  assert!(
+    HistoricalRun::find_current(&corpus, &service, &mut backend.connection)
+      .expect("current B")
+      .is_some(),
+    "the run is still open while a task is blocked"
+  );
+
+  // (C) Resolve the Blocked task to a terminal Error → fully drained → the run closes, freezing its
+  // final tallies (3 NoProblem: the 2 seeded + the cleared TODO; 2 Error: the seed + the resolved
+  // block).
+  diesel::update(tasks::table.filter(tasks::id.eq(blocked_id)))
+    .set(tasks::status.eq(TaskStatus::Error.raw()))
+    .execute(&mut backend.connection)
+    .expect("resolve block");
+  let closed = HistoricalRun::complete_if_drained(corpus.id, service.id, &mut backend.connection)
+    .expect("drain check C");
+  assert!(closed, "a fully-terminal pair drains → the run is closed");
+  assert!(
+    HistoricalRun::find_current(&corpus, &service, &mut backend.connection)
+      .expect("current C")
+      .is_none(),
+    "no open run remains after the close"
+  );
+  let run = HistoricalRun::find_by(&corpus, &service, &mut backend.connection)
+    .expect("runs")
+    .into_iter()
+    .next()
+    .expect("the closed run");
+  assert!(run.end_time.is_some(), "the closed run has an end_time");
+  assert_eq!(run.no_problem, 3, "frozen tallies: 3 no_problem");
+  assert_eq!(run.error, 2, "frozen tallies: 2 error");
+  assert_eq!(run.total, 5, "frozen total excludes invalids (3 + 2)");
+
+  // (D) Idempotent: re-checking a drained pair closes nothing (no open run left).
+  let closed = HistoricalRun::complete_if_drained(corpus.id, service.id, &mut backend.connection)
+    .expect("drain check D");
+  assert!(
+    !closed,
+    "re-checking a drained pair closes nothing (idempotent)"
+  );
+
+  // (E) Bookkeeping skip: open a run for the `import` service (id 2) with NO tasks — drained by the
+  // task count — and assert the `service <= 2` guard refuses to close it (init/import are not
+  // user-facing conversion runs, so without the guard a zero-task pair would close immediately).
+  let import = Service::find_by_name("import", &mut backend.connection).expect("import service");
+  assert!(import.id <= 2, "import is a bookkeeping service id");
+  backend
+    .mark_new_run(
+      &corpus,
+      &import,
+      "tester".into(),
+      "import bookkeeping".into(),
+    )
+    .expect("open import run");
+  let closed = HistoricalRun::complete_if_drained(corpus.id, import.id, &mut backend.connection)
+    .expect("drain check E");
+  assert!(
+    !closed,
+    "the bookkeeping import service is skipped even when drained"
+  );
+  assert!(
+    HistoricalRun::find_current(&corpus, &import, &mut backend.connection)
+      .expect("current E")
+      .is_some(),
+    "the import bookkeeping run stays open (guarded)"
+  );
+
+  // Clean up so a re-run starts fresh.
+  diesel::delete(historical_runs::table.filter(historical_runs::corpus_id.eq(corpus.id)))
+    .execute(&mut backend.connection)
+    .ok();
+  diesel::delete(tasks::table.filter(tasks::corpus_id.eq(corpus.id)))
+    .execute(&mut backend.connection)
+    .ok();
+  diesel::delete(corpora::table.filter(corpora::id.eq(corpus.id)))
+    .execute(&mut backend.connection)
+    .ok();
+  diesel::delete(services::table.filter(services::name.eq(service_name)))
+    .execute(&mut backend.connection)
+    .ok();
+}
+
 fn main() {
   // Own the Client in `main` and `process::exit(0)` while it is still alive — never dropping it, so
   // the racy libpq/Tokio/r2d2 teardown never runs (the bench's `process::exit` trick).
@@ -193,6 +379,7 @@ fn main() {
   overview_overlays_live_tallies_via_batch(&client);
   overview_lists_runs_system_wide(&client);
   history_chart_escapes_script_breakout_in_a_description(&client);
+  run_completion_on_drain_closes_only_a_fully_drained_run();
   eprintln!("runs_test: all cases passed");
   // `_exit` (not `process::exit`): skip C atexit handlers — libpq/OpenSSL global cleanup races with
   // the still-live Tokio/r2d2 threads and SIGSEGVs (L-1). The OS reclaims everything cleanly.

--- a/tests/runs_test.rs
+++ b/tests/runs_test.rs
@@ -353,6 +353,29 @@ fn run_completion_on_drain_closes_only_a_fully_drained_run() {
     "the import bookkeeping run stays open (guarded)"
   );
 
+  // (F) Atomic compare-and-set: closing the SAME loaded (stale) run object twice — the
+  // duplicate-last-task / racing-writer shape — must close EXACTLY once. Re-open a conversion run
+  // (its tasks are all terminal from (C), so it is drained), load it, then close it twice on the
+  // same stale handle: the first wins (`rows == 1`), the second's `end_time IS NULL` predicate
+  // matches zero rows and is a clean no-op, never a re-mark.
+  backend
+    .mark_new_run(&corpus, &service, "tester".into(), "cas run".into())
+    .expect("reopen conversion run");
+  let stale = HistoricalRun::find_current(&corpus, &service, &mut backend.connection)
+    .expect("find reopened")
+    .expect("an open run to close");
+  let first = stale
+    .mark_completed(&mut backend.connection)
+    .expect("first close");
+  let second = stale
+    .mark_completed(&mut backend.connection)
+    .expect("second close");
+  assert!(first, "the first close of an open run wins (rows == 1)");
+  assert!(
+    !second,
+    "closing the same stale run object again is a no-op (compare-and-set, never a double-mark)"
+  );
+
   // Clean up so a re-run starts fresh.
   diesel::delete(historical_runs::table.filter(historical_runs::corpus_id.eq(corpus.id)))
     .execute(&mut backend.connection)


### PR DESCRIPTION
## Why

A finished conversion run read as **"ongoing"** until the very minute the *next* rerun started: `end_time` was only set lazily, by `mark_new_run` closing the prior run. A run that finished could sit "ongoing" for days/weeks until someone reran the corpus. This makes the dispatcher detect drain and close the run right away.

## Mechanism

Rides the finalize thread's existing `touched`-scope + idle cadence — no new timer or thread:

- **`HistoricalRun::complete_if_drained(corpus, service, conn)`** — closes the pair's open run iff no task remains outside the terminal severity band `[-5, -1]` (i.e. nothing `TODO`/`Queued`/`Blocked`). Skips the bookkeeping services `init`(1)/`import`(2).
- **`Backend::complete_run_if_drained`** delegates to it.
- **`finalize::settle_touched`** runs run-completion *before* the existing report-cache invalidation at every drain / idle / shutdown checkpoint.

The close lands within **~1s of the queue going idle**, and **never prematurely**: a still-`Queued` long conversion keeps the count `> 0`, so the close only fires on the next idle tick after the genuinely-last result lands — self-correcting.

## Correctness: no double-mark

`mark_completed` is now an **atomic compare-and-set**: the open-row predicate lives in the write —

```sql
UPDATE historical_runs SET end_time = now(), <frozen tallies>
 WHERE id = ? AND end_time IS NULL
```

— and it returns `true` iff *this* call matched the row (`rows == 1`). A duplicate finalize pass (a re-tried last task that lands twice) or any racing writer that finds the run already closed matches zero rows → clean no-op, never a second completion. `complete_if_drained` propagates that winner signal, so its `true` is a safe edge to hang a future run-completion side effect on (it can never double-fire). A fast-path `self.end_time.is_some()` early-return avoids recomputing tallies in the already-closed case; the `WHERE` clause is the real guard.

## Validation

- **`dispatcher_bench`** opens a run, drains the backlog, and asserts the run is **closed on drain** (`end_time` set) — a new correctness gate alongside the no-loss / all-terminal / status-distribution gates. Verified end-to-end: `run-completion: closed on drain ✓`.
- **`runs_test`** (model boundary) pins every branch: `TODO` and `Blocked` each keep a run open; full drain closes it with frozen tallies; the close is idempotent; `init`/`import` are skipped even when drained; and closing the **same stale loaded run twice wins exactly once** (the compare-and-set, the duplicate-last-task shape).
- Green locally: lib `55/0`, `runs_test`, `rerun_test`, `report_rollup_test`, `dispatcher_bench`. (`cargo clippy -D warnings` clean.)

Disjoint from #374 (deploy/systemd/`ventilator.rs`); merges cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)