### PR TITLE
tune(dispatcher): lease 180s→240s, coupled with worker conversion timeout 120s→180s

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -127,9 +127,10 @@ pub struct DispatcherConfig {
   /// timing out waits progressively longer rather than re-leasing ever-faster
   /// ([`crate::helpers::TaskProgress::expected_at`]). This is the correctness net for a *silently
   /// dead / half-open* worker (no ZMTP heartbeat needed): its task is recovered once the lease
-  /// lapses. Default **180** — just above the worker's hard per-document timeout (the CorTeX
-  /// `latexml` fleet caps each conversion at 120 s and *hard-kills* the process on overrun), which
-  /// bounds any single conversion's runtime. With that cap, a lease expiry reliably means the
+  /// lapses. Default **240** — just above the worker's hard per-document timeout (the CorTeX
+  /// `latexml` fleet caps each conversion at 180 s and *hard-kills* the process on overrun), with
+  /// a 60 s margin, which bounds any single conversion's runtime. With that cap, a lease expiry
+  /// reliably means the
   /// worker **died** (timeout / OOM kill) on an unprocessable paper, so prompt re-lease — and,
   /// after `MAX_DISPATCH_RETRIES`, dead-letter to `Fatal` — recovers the task *within the run*
   /// instead of stranding it for an hour (orphaned-lease tail observed at scale). Raise it only
@@ -170,7 +171,7 @@ impl Default for DispatcherConfig {
       sink_writers: 4,
       finalize_batch_size: 1024,
       finalize_flush_ms: 300,
-      lease_timeout_seconds: 180,
+      lease_timeout_seconds: 240,
       reap_interval_seconds: 60,
       tcp_keepalive_idle_seconds: 120,
     }

--- a/src/dispatcher/server.rs
+++ b/src/dispatcher/server.rs
@@ -304,7 +304,7 @@ pub fn send_done(done_tx: &SyncSender<TaskReport>, report: TaskReport) {
 /// A task re-dispatched this many times that still never returns a result is treated as a hard
 /// failure (`Fatal`) rather than retried forever.
 ///
-/// **1** with the short `lease_timeout_seconds` (~180 s, just above the worker's hard per-document
+/// **1** with the short `lease_timeout_seconds` (~240 s, just above the worker's 180 s per-document
 /// timeout): a task whose worker keeps dying is almost always an unprocessable paper (a fresh
 /// recycle-clean worker dies on it too), so 2 retries (3 attempts total) catch the rare
 /// transient/worker-induced death and then converge to `Fatal` within a single run — the


### PR DESCRIPTION
## Why
The worker's per-document conversion timeout was raised **120s → 180s** (latexml-oxide `cortex_worker`, commit `6c6a418`) to recover genuine **120–180s converging** papers that valid-but-lost to the wall (triage witness `1810.05740` @131s produces valid HTML). The dispatcher lease is **coupled** to that cap:

> the lease MUST stay above the conversion timeout with margin, so a lease expiry reliably means a **dead** worker — not a slow-but-live one — otherwise the reaper double-leases a paper still being converted.

So the coupled lease default moves **180 → 240** (180s conversion + 60s margin), preserving the invariant.

## What
- `config.rs`: `DispatcherConfig::default().lease_timeout_seconds` 180 → 240 + doc.
- `server.rs`: `MAX_DISPATCH_RETRIES` doc updated (~180s → ~240s lease, ~180s conversion).
- The operative runtime value is the gitignored/skip-worktree local `cortex.toml`, already set to 240 and live on the dispatcher; this records the code default to match.

## Context
Part of the 10k-sandbox fleet-tuning pass: also shipped the worker recycle default 50%→25% (2048) which dropped peak fleet RSS 188→127 GB and governor sheds 25→1 at the CPU-optimal 72 workers, with byte-identical conversion outcomes. Move the two timeouts together if either is retuned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)