### PR TITLE
fix(parser): classify Fatal:invalid:* as the distinct Invalid status (Perl parity)

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -377,6 +377,18 @@ impl NewTaskMessage {
         what,
         details,
       }),
+      // Perl-LaTeXML emits `Fatal('invalid', …)` for an *unprocessable input* (no TeX source,
+      // PDF-only, binary, …): a fatal whose CATEGORY is `invalid`. CorTeX treats that as its
+      // distinct **Invalid** outcome — its own report row, discounted from the total — not a plain
+      // conversion Fatal. This is the bridge that realizes the long-noted intent in
+      // `generate_report` ("they're fatal messages in latexml, but we want them separated out in
+      // cortex"); the literal `invalid:` severity below resolves to the same record.
+      "fatal" if category == "invalid" => NewTaskMessage::Invalid(NewLogInvalid {
+        task_id,
+        category,
+        what,
+        details,
+      }),
       "fatal" => NewTaskMessage::Fatal(NewLogFatal {
         category,
         task_id,
@@ -712,6 +724,30 @@ mod log_decode_tests {
     );
     let canonical = parse_log(42, "Warning:missing_file:x y\n");
     assert!(matches!(canonical[0], NewTaskMessage::Warning(_)));
+  }
+
+  #[test]
+  fn fatal_invalid_category_is_separated_into_invalid() {
+    // Perl-LaTeXML emits `Fatal('invalid', …)` for an unprocessable input (no TeX source,
+    // PDF-only, binary). cortex must separate that out as its distinct **Invalid** outcome (own
+    // report row, discounted from the total) — NOT a plain conversion Fatal — even though the
+    // severity token is `Fatal`. The bridge keys on the `invalid` category.
+    use super::NewTaskMessage;
+    let m = parse_log(
+      7,
+      "Fatal:invalid:no_tex_source no .tex files found in archive\n",
+    );
+    assert_eq!(m.len(), 1);
+    assert!(
+      matches!(m[0], NewTaskMessage::Invalid(_)),
+      "a Fatal message in the `invalid` category is filed as Invalid, not Fatal"
+    );
+    // A fatal in any OTHER category is still a plain Fatal.
+    let f = parse_log(7, "Fatal:conversion:caught boom\n");
+    assert!(matches!(f[0], NewTaskMessage::Fatal(_)));
+    // And the literal `Invalid:` severity (e.g. the sink's oversize-reject) still maps to Invalid.
+    let i = parse_log(7, "Invalid:size:too_big result exceeds cap\n");
+    assert!(matches!(i[0], NewTaskMessage::Invalid(_)));
   }
 
   #[test]


### PR DESCRIPTION
## Why
Perl-LaTeXML signals an **unprocessable input** (no TeX source, PDF-only, binary misnamed `.tex`) as `Fatal('invalid', '<what>', …)` — severity `Fatal`, **category `invalid`**. CorTeX has always meant to separate these out as its distinct **Invalid** outcome (own `log_invalids` report row, *discounted from the total*) — `generate_report` even says so: *"they're fatal messages in latexml, but we want them separated out in cortex."*

But `NewTaskMessage::new` only produced an Invalid record for a **literal `Invalid:` severity**, which Perl never emits — so those messages fell through to plain Fatal and the Invalid row stayed empty (run 177: 0 invalids despite ~90 no-TeX-source papers).

## What
Add the bridge: a `fatal` message whose **category is `invalid`** → Invalid record → `generate_report` promotes the task to `TaskStatus::Invalid` (final). Literal `Invalid:` (the sink's oversize-reject) unchanged.

Companion to latexml-oxide `cortex_worker` (commit `5a78522`) now emitting `Fatal:invalid:<what>` (`no_tex_source`/`no_viable_tex`/`not_tex_source`) for the no-convertible-source paths, mirroring Perl's `Core.pm`.

## Effect
On sandbox-arxiv-10k: ~90 unprocessable-input papers move **Fatal→Invalid** — their own row, discounted from the OK-rate denominator. No fake conversions; pure Perl/CorTeX-parity reclassification.

Unit test: `fatal_invalid_category_is_separated_into_invalid` (Fatal:invalid→Invalid; other fatals stay Fatal; literal Invalid: still maps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)