### PR TITLE
feat(report): unify Rerun-Progress + Full-Corpus into one progress + outcomes report

### DIFF
--- a/public/css/cortex.css
+++ b/public/css/cortex.css
@@ -1607,6 +1607,19 @@ h3 {
 .bar.todo {
   background-color: var(--ink-muted);
 }
+/* Progress (how-far-through) bar — deliberately NEUTRAL + striped so it reads as "progress",
+   not as a severity. Reusing a severity colour (e.g. the green .bar.ok) would clash with the
+   outcome rows below it. Diagonal translucent stripes over the muted ink work in light + dark. */
+.bar.progress {
+  background-color: var(--ink-muted);
+  background-image: repeating-linear-gradient(
+    45deg,
+    rgba(255, 255, 255, 0.22) 0,
+    rgba(255, 255, 255, 0.22) 6px,
+    transparent 6px,
+    transparent 12px
+  );
+}
 .report-table tr.report-total > td {
   border-top: 2px solid var(--rule);
   font-weight: 700;

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -25,6 +25,7 @@ pub(crate) use mark::{
 // per-task changed-tasks drill a third (CLI) surface alongside the agent `/api/runs/<c>/<s>/tasks`
 // and the web screen.
 pub use reports::list_task_diffs;
+pub(crate) use reports::live_run_diff;
 pub(crate) use reports::progress_report;
 pub(crate) use reports::report_uses_rollup;
 // `pub` (not `pub(crate)`): the `cortex` CLI's `diff` subcommand calls it directly, so the run-diff
@@ -318,7 +319,23 @@ impl Backend {
     corpus_id: i32,
     service_id: i32,
   ) -> Result<bool, Error> {
-    crate::models::HistoricalRun::complete_if_drained(corpus_id, service_id, &mut self.connection)
+    let closed = crate::models::HistoricalRun::complete_if_drained(
+      corpus_id,
+      service_id,
+      &mut self.connection,
+    )?;
+    if closed {
+      // The run just closed on drain — its per-task outcomes are settled. Snapshot them into
+      // `historical_tasks` as the BASELINE for the NEXT run's live run-diff: captured once, here,
+      // at the natural completion point (in the finalize thread, off the request path). Best-effort
+      // — a snapshot failure must never undo the (critical) run close, so log and carry on.
+      if let Err(e) = mark::snapshot_tasks(&mut self.connection, corpus_id, service_id) {
+        tracing::warn!(
+          "run-completion-on-drain: baseline snapshot for ({corpus_id}, {service_id}) failed (non-fatal): {e:?}"
+        );
+      }
+    }
+    Ok(closed)
   }
   /// Category-grain report for `(corpus, service, severity)`, read from the `report_summary`
   /// rollup, windowed to `[offset, offset + limit)` (ordered by descending task count).

--- a/src/backend/mark.rs
+++ b/src/backend/mark.rs
@@ -397,14 +397,26 @@ pub fn save_historical_tasks(
   corpus: &Corpus,
   service: &Service,
 ) -> Result<usize, Error> {
-  //  create batch copy query
-  let insert_query = insert_into(historical_tasks::table)
+  snapshot_tasks(connection, corpus.id, service.id)
+}
+
+/// Freeze the current per-task statuses of a `(corpus, service)` into `historical_tasks` — the
+/// id-keyed core of [`save_historical_tasks`]. Called both by the human "save snapshot" and, on
+/// **run-completion-on-drain**, to capture the just-finished run's outcomes as the **baseline** for
+/// the next run's live run-diff (see `backend::Backend::complete_run_if_drained`). One
+/// `INSERT … SELECT` of scope-size rows; retention/pruning of stale snapshots is a follow-up.
+pub fn snapshot_tasks(
+  connection: &mut PgConnection,
+  corpus_id: i32,
+  service_id: i32,
+) -> Result<usize, Error> {
+  insert_into(historical_tasks::table)
     .values(
       tasks::table
         .select((tasks::id, tasks::status))
-        .filter(tasks::corpus_id.eq(corpus.id))
-        .filter(tasks::service_id.eq(service.id)),
+        .filter(tasks::corpus_id.eq(corpus_id))
+        .filter(tasks::service_id.eq(service_id)),
     )
-    .into_columns((historical_tasks::task_id, historical_tasks::status));
-  insert_query.execute(connection)
+    .into_columns((historical_tasks::task_id, historical_tasks::status))
+    .execute(connection)
 }

--- a/src/backend/reports.rs
+++ b/src/backend/reports.rs
@@ -27,14 +27,21 @@ static TASK_REPORT_NAME_REGEX: LazyLock<Regex> =
 pub struct LiveRunDiff {
   /// completed tasks whose current outcome is *better* than the baseline (status int higher)
   pub improved: i64,
-  /// completed tasks whose current outcome is *worse* than the baseline (status int lower)
+  /// completed tasks whose current outcome is *worse* than the baseline (status int lower) —
+  /// excludes `Invalid` transitions (those are `reclassified`, not a quality regression)
   pub regressed: i64,
   /// completed tasks at the same outcome as the baseline
   pub unchanged: i64,
+  /// completed tasks where one side is `Invalid` (unprocessable input) and the other is not — a
+  /// reclassification (e.g. a source that became / stopped being convertible), NOT a quality
+  /// improvement or regression, so it gets its own bucket rather than masquerading as one.
+  pub reclassified: i64,
 }
 impl LiveRunDiff {
   /// Total completed tasks that had a baseline to compare against.
-  pub fn compared(&self) -> i64 { self.improved + self.regressed + self.unchanged }
+  pub fn compared(&self) -> i64 {
+    self.improved + self.regressed + self.unchanged + self.reclassified
+  }
 }
 
 #[derive(QueryableByName)]
@@ -45,6 +52,8 @@ struct DiffRow {
   regressed: i64,
   #[diesel(sql_type = diesel::sql_types::BigInt)]
   unchanged: i64,
+  #[diesel(sql_type = diesel::sql_types::BigInt)]
+  reclassified: i64,
 }
 
 /// Process-local read-through cache for [`live_run_diff`]. The diff is a join (`tasks` ⋈ the
@@ -90,11 +99,15 @@ fn compute_live_run_diff(
   corpus_id: i32,
   service_id: i32,
 ) -> LiveRunDiff {
+  // Invalid (-5) is "unprocessable input", not a quality grade — so an Invalid transition is
+  // counted as `reclassified`, never improved/regressed (it would otherwise read as the worst
+  // regression by raw int order). improved/regressed compare only NON-invalid outcomes.
   let row: Option<DiffRow> = sql_query(
     "SELECT \
-       count(*) FILTER (WHERE t.status > b.status)::bigint AS improved, \
-       count(*) FILTER (WHERE t.status < b.status)::bigint AS regressed, \
-       count(*) FILTER (WHERE t.status = b.status)::bigint AS unchanged \
+       count(*) FILTER (WHERE t.status <> b.status AND t.status <> -5 AND b.status <> -5 AND t.status > b.status)::bigint AS improved, \
+       count(*) FILTER (WHERE t.status <> b.status AND t.status <> -5 AND b.status <> -5 AND t.status < b.status)::bigint AS regressed, \
+       count(*) FILTER (WHERE t.status = b.status)::bigint AS unchanged, \
+       count(*) FILTER (WHERE t.status <> b.status AND (t.status = -5 OR b.status = -5))::bigint AS reclassified \
      FROM tasks t \
      JOIN ( \
        SELECT DISTINCT ON (h.task_id) h.task_id, h.status \
@@ -115,6 +128,7 @@ fn compute_live_run_diff(
       improved: r.improved,
       regressed: r.regressed,
       unchanged: r.unchanged,
+      reclassified: r.reclassified,
     },
     None => LiveRunDiff::default(),
   }

--- a/src/backend/reports.rs
+++ b/src/backend/reports.rs
@@ -3,7 +3,8 @@ use diesel::dsl::sql;
 use diesel::*;
 use regex::Regex;
 use std::collections::HashMap;
-use std::sync::LazyLock;
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
 
 use super::rollup;
 use crate::frontend::helpers::severity_highlight;
@@ -17,6 +18,107 @@ use crate::schema::tasks;
 
 static TASK_REPORT_NAME_REGEX: LazyLock<Regex> =
   LazyLock::new(|| Regex::new(r"^.+/(.+)\..+$").unwrap());
+
+/// Live run-diff aggregate: of the tasks **completed so far** in the current run, how many
+/// improved / regressed / stayed the same vs their outcome in the previous run's baseline snapshot
+/// (`historical_tasks`, captured at the prior run's completion-on-drain). A coarse early-divergence
+/// signal — "is this run tracking the last one, or diverging?" — readable before the run finishes.
+#[derive(Clone, Debug, Default)]
+pub struct LiveRunDiff {
+  /// completed tasks whose current outcome is *better* than the baseline (status int higher)
+  pub improved: i64,
+  /// completed tasks whose current outcome is *worse* than the baseline (status int lower)
+  pub regressed: i64,
+  /// completed tasks at the same outcome as the baseline
+  pub unchanged: i64,
+}
+impl LiveRunDiff {
+  /// Total completed tasks that had a baseline to compare against.
+  pub fn compared(&self) -> i64 { self.improved + self.regressed + self.unchanged }
+}
+
+#[derive(QueryableByName)]
+struct DiffRow {
+  #[diesel(sql_type = diesel::sql_types::BigInt)]
+  improved: i64,
+  #[diesel(sql_type = diesel::sql_types::BigInt)]
+  regressed: i64,
+  #[diesel(sql_type = diesel::sql_types::BigInt)]
+  unchanged: i64,
+}
+
+/// Process-local read-through cache for [`live_run_diff`]. The diff is a join (`tasks` ⋈ the
+/// baseline snapshot) — the only *expensive* part of the report — so compute it at most once per
+/// `LIVE_DIFF_TTL` per scope and serve every page load from the memo. This decouples the heavy
+/// compute from the frequent reads (the report is loaded tens of times/min by collaborators), so
+/// read volume can't load the DB. The headline severity counts stay LIVE (a cheap grouped count);
+/// only this join earns a cache. Bounded staleness (≤ TTL) is acceptable — a live-diff is an early
+/// *trend*, not an exact figure.
+/// `(corpus_id, service_id)` → (computed-at, diff). Process-local memo behind [`LIVE_DIFF_CACHE`].
+type LiveDiffCache = Mutex<HashMap<(i32, i32), (Instant, LiveRunDiff)>>;
+static LIVE_DIFF_CACHE: LazyLock<LiveDiffCache> = LazyLock::new(|| Mutex::new(HashMap::new()));
+const LIVE_DIFF_TTL: Duration = Duration::from_secs(5);
+
+/// Read-through-cached [`compute_live_run_diff`] (see [`LIVE_DIFF_CACHE`]).
+pub fn live_run_diff(
+  connection: &mut PgConnection,
+  corpus_id: i32,
+  service_id: i32,
+) -> LiveRunDiff {
+  let key = (corpus_id, service_id);
+  {
+    // Recover a poisoned lock rather than panic — a stale diff is harmless.
+    let cache = LIVE_DIFF_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    match cache.get(&key) {
+      Some((at, diff)) if at.elapsed() < LIVE_DIFF_TTL => return diff.clone(),
+      _ => {},
+    }
+    // Lock dropped here, BEFORE the DB query — never hold it across the join.
+  }
+  let diff = compute_live_run_diff(connection, corpus_id, service_id);
+  let mut cache = LIVE_DIFF_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+  cache.insert(key, (Instant::now(), diff.clone()));
+  diff
+}
+
+/// Of the tasks completed so far (`status < 0`), compare each to its status in the LATEST baseline
+/// snapshot. Severity ints are ordered best→worst (`no_problem` -1 … `invalid` -5), so a *higher*
+/// current status than the baseline is an improvement, lower a regression. `DISTINCT ON` picks each
+/// task's most-recent snapshot (the prior run's completion). This join is the cached cost.
+fn compute_live_run_diff(
+  connection: &mut PgConnection,
+  corpus_id: i32,
+  service_id: i32,
+) -> LiveRunDiff {
+  let row: Option<DiffRow> = sql_query(
+    "SELECT \
+       count(*) FILTER (WHERE t.status > b.status)::bigint AS improved, \
+       count(*) FILTER (WHERE t.status < b.status)::bigint AS regressed, \
+       count(*) FILTER (WHERE t.status = b.status)::bigint AS unchanged \
+     FROM tasks t \
+     JOIN ( \
+       SELECT DISTINCT ON (h.task_id) h.task_id, h.status \
+       FROM historical_tasks h JOIN tasks tt ON tt.id = h.task_id \
+       WHERE tt.corpus_id = $1 AND tt.service_id = $2 \
+       ORDER BY h.task_id, h.saved_at DESC \
+     ) b ON b.task_id = t.id \
+     WHERE t.corpus_id = $1 AND t.service_id = $2 AND t.status < 0",
+  )
+  .bind::<diesel::sql_types::Integer, _>(corpus_id)
+  .bind::<diesel::sql_types::Integer, _>(service_id)
+  .get_result(connection)
+  .optional()
+  .ok()
+  .flatten();
+  match row {
+    Some(r) => LiveRunDiff {
+      improved: r.improved,
+      regressed: r.regressed,
+      unchanged: r.unchanged,
+    },
+    None => LiveRunDiff::default(),
+  }
+}
 
 /// Maximum messages loaded **per severity** for a single document's forensic view. A hostile or
 /// pathological document can carry millions of messages of one severity (observed in production: a

--- a/src/frontend/concerns.rs
+++ b/src/frontend/concerns.rs
@@ -12,8 +12,8 @@ use std::str;
 use std::sync::Arc;
 
 use crate::backend::{
-  DbPool, PooledConn, RerunOptions, mark_all_blocked, mark_blocked, mark_rerun, progress_report,
-  resume_all_blocked, resume_blocked, save_historical_tasks,
+  DbPool, PooledConn, RerunOptions, live_run_diff, mark_all_blocked, mark_blocked, mark_rerun,
+  progress_report, resume_all_blocked, resume_blocked, save_historical_tasks,
 };
 use crate::frontend::actor::AdminSession;
 use crate::frontend::helpers::*;
@@ -205,6 +205,16 @@ pub fn serve_report(
             "0.00".to_string()
           },
         );
+        // Live run-diff: of the tasks completed so far, how many improved / regressed / stayed the
+        // same vs the previous run's baseline snapshot. Read-through cached (the join is the only
+        // expensive bit — the headline counts above stay live), shown only once there's a baseline
+        // and something completed to compare.
+        let ld = live_run_diff(connection, corpus.id, service.id);
+        if ld.compared() > 0 {
+          global.insert("livediff_improved".to_string(), ld.improved.to_string());
+          global.insert("livediff_regressed".to_string(), ld.regressed.to_string());
+          global.insert("livediff_unchanged".to_string(), ld.unchanged.to_string());
+        }
         // Record the report into the globals
         for (key, val) in report {
           global.insert(key.clone(), val.to_string());

--- a/src/frontend/concerns.rs
+++ b/src/frontend/concerns.rs
@@ -214,6 +214,10 @@ pub fn serve_report(
           global.insert("livediff_improved".to_string(), ld.improved.to_string());
           global.insert("livediff_regressed".to_string(), ld.regressed.to_string());
           global.insert("livediff_unchanged".to_string(), ld.unchanged.to_string());
+          global.insert(
+            "livediff_reclassified".to_string(),
+            ld.reclassified.to_string(),
+          );
         }
         // Record the report into the globals
         for (key, val) in report {

--- a/src/frontend/concerns.rs
+++ b/src/frontend/concerns.rs
@@ -194,6 +194,17 @@ pub fn serve_report(
         global.insert("rerun_warning_percent".to_string(), pct(warn));
         global.insert("rerun_error_percent".to_string(), pct(err));
         global.insert("rerun_fatal_percent".to_string(), pct(fat));
+        // Unified report's progress bar: share of the non-invalid corpus processed so far
+        // (`total` is the non-invalid size — progress_report discounts invalids).
+        let total = count("total");
+        global.insert(
+          "processed_percent".to_string(),
+          if total > 0.0 {
+            format!("{:.2}", 100.0 * completed / total)
+          } else {
+            "0.00".to_string()
+          },
+        );
         // Record the report into the globals
         for (key, val) in report {
           global.insert(key.clone(), val.to_string());

--- a/templates/report.html.tera
+++ b/templates/report.html.tera
@@ -7,47 +7,25 @@
   </header>
 
   <div id="report-div">
-    {# While a conversion is in progress (queued > 0), show the run's completed-so-far
-       breakdown. Computed server-side in serve_report (rerun_* globals) — this used to
-       be built client-side by progress_report.js scraping these cells, which truncated
-       counts >= 1000 at the thousands separator. #}
-    {% if global.queued and global.queued != "0" %}
-    <h2>Rerun Progress</h2>
-    <table class="table">
-      <thead>
-        <tr><th class="left">Status</th><th class="right">Percent</th><th class="right">Tasks</th></tr>
-      </thead>
-      <tbody>
-        <tr class="success corpus-report-no-problems">
-          <td class="left">No problems</td>
-          <td class="right">{{ global.rerun_no_problem_percent }}%</td>
-          <td class="right">{{ global.no_problem | group_thousands }}</td>
-        </tr>
-        <tr class="warning corpus-report-warnings">
-          <td class="left">Warning</td>
-          <td class="right">{{ global.rerun_warning_percent }}%</td>
-          <td class="right">{{ global.warning | group_thousands }}</td>
-        </tr>
-        <tr class="error corpus-report-errors">
-          <td class="left">Error</td>
-          <td class="right">{{ global.rerun_error_percent }}%</td>
-          <td class="right">{{ global.error | group_thousands }}</td>
-        </tr>
-        <tr class="danger corpus-report-fatal">
-          <td class="left">Fatal</td>
-          <td class="right">{{ global.rerun_fatal_percent }}%</td>
-          <td class="right">{{ global.fatal | group_thousands }}</td>
-        </tr>
-        <tr class="corpus-report-completed">
-          <td class="left">Completed</td>
-          <td class="right">100%</td>
-          <td class="right">{{ global.rerun_completed | group_thousands }}</td>
-        </tr>
-      </tbody>
-    </table>
-    <h2>Full Corpus</h2>
-    {% endif %}
+    {# Unified report: a progress line (how far through the corpus) + an outcomes table (the
+       quality of what's been processed, as a share of `completed`). Replaces the old split
+       "Rerun Progress" (over completed) and "Full Corpus" (over total) tables — same counts,
+       two denominators, redundant at completion and only divergent mid-run, where the
+       over-total %s were diluted by the not-yet-done pile. Outcome %s are over `completed`
+       always: the running quality mid-run, the final breakdown when done. Progress is shown
+       apart so "awaiting"/"in progress" are not peers of the quality outcomes. #}
+    <div class="report-progress">
+      <span class="bar-track" style="display:block;width:100%"><span class="bar ok" style="--bar-width: {{ global.processed_percent | default(value='0') }}%"></span></span>
+      <p class="report-progress-summary">
+        <strong>{{ global.rerun_completed | group_thousands }}</strong> of {{ global.total | group_thousands }} processed
+        <span class="report-sep">·</span> {{ global.processed_percent | float(default=0) | round }}%
+        {% if global.todo and global.todo != "0" %}<span class="report-sep">·</span> {{ global.todo | group_thousands }} awaiting{% endif %}
+        {% if global.queued and global.queued != "0" %}<span class="report-sep">·</span> <a href="/workers/{{global.service_name_uri}}">{{ global.queued | group_thousands }} in&nbsp;progress</a>{% endif %}
+        {% if global.blocked and global.blocked != "0" %}<span class="report-sep">·</span> {{ global.blocked | group_thousands }} blocked{% endif %}
+      </p>
+    </div>
     <table id="corpus-report" class="table report-table">
+      <caption class="report-caption">Outcomes <span class="report-sep">·</span> share of {{ global.rerun_completed | group_thousands }} processed</caption>
       <thead>
         <tr>
           <th scope="col" class="left">Status</th>
@@ -59,58 +37,38 @@
       <tbody>
         <tr class="corpus-report-no-problems">
           <td class="left"><a href="/corpus/{{global.corpus_name_uri}}/{{global.service_name_uri}}/no_problem">No problems</a></td>
-          <td class="bar-cell"><span class="bar-track"><span class="bar ok" style="--bar-width: {{global.no_problem_percent}}%"></span></span></td>
-          <td class="right">{{ global.no_problem_percent | float(default=0) | round }}%</td>
+          <td class="bar-cell"><span class="bar-track"><span class="bar ok" style="--bar-width: {{global.rerun_no_problem_percent}}%"></span></span></td>
+          <td class="right">{{ global.rerun_no_problem_percent | float(default=0) | round }}%</td>
           <td class="right no-problem count-ok">{{ global.no_problem | group_thousands }}</td>
         </tr>
         <tr class="corpus-report-warnings">
           <td class="left"><a href="/corpus/{{global.corpus_name_uri}}/{{global.service_name_uri}}/warning">Warning</a></td>
-          <td class="bar-cell"><span class="bar-track"><span class="bar warn" style="--bar-width: {{global.warning_percent}}%"></span></span></td>
-          <td class="right">{{ global.warning_percent | float(default=0) | round }}%</td>
+          <td class="bar-cell"><span class="bar-track"><span class="bar warn" style="--bar-width: {{global.rerun_warning_percent}}%"></span></span></td>
+          <td class="right">{{ global.rerun_warning_percent | float(default=0) | round }}%</td>
           <td class="right warning count-warn">{{ global.warning | group_thousands }}</td>
         </tr>
         <tr class="corpus-report-errors">
           <td class="left"><a href="/corpus/{{global.corpus_name_uri}}/{{global.service_name_uri}}/error">Error</a></td>
-          <td class="bar-cell"><span class="bar-track"><span class="bar error" style="--bar-width: {{global.error_percent}}%"></span></span></td>
-          <td class="right">{{ global.error_percent | float(default=0) | round }}%</td>
+          <td class="bar-cell"><span class="bar-track"><span class="bar error" style="--bar-width: {{global.rerun_error_percent}}%"></span></span></td>
+          <td class="right">{{ global.rerun_error_percent | float(default=0) | round }}%</td>
           <td class="right error count-error">{{ global.error | group_thousands }}</td>
         </tr>
         <tr class="corpus-report-fatal">
           <td class="left"><a href="/corpus/{{global.corpus_name_uri}}/{{global.service_name_uri}}/fatal">Fatal</a></td>
-          <td class="bar-cell"><span class="bar-track"><span class="bar fatal" style="--bar-width: {{global.fatal_percent}}%"></span></span></td>
-          <td class="right">{{ global.fatal_percent | float(default=0) | round }}%</td>
+          <td class="bar-cell"><span class="bar-track"><span class="bar fatal" style="--bar-width: {{global.rerun_fatal_percent}}%"></span></span></td>
+          <td class="right">{{ global.rerun_fatal_percent | float(default=0) | round }}%</td>
           <td class="right fatal count-fatal">{{ global.fatal | group_thousands }}</td>
         </tr>
-        <tr>
-          <td class="left">Awaiting processing</td>
-          <td class="bar-cell"><span class="bar-track"><span class="bar todo" style="--bar-width: {{global.todo_percent}}%"></span></span></td>
-          <td class="right">{{ global.todo_percent | float(default=0) | round }}%</td>
-          <td class="right todo count-todo">{{ global.todo | group_thousands }}</td>
-        </tr>
-        <tr>
-          <td class="left"><a href="/workers/{{global.service_name_uri}}">In progress</a></td>
-          <td class="bar-cell"><span class="bar-track"><span class="bar" style="--bar-width: {{global.queued_percent}}%"></span></span></td>
-          <td class="right">{{ global.queued_percent | float(default=0) | round }}%</td>
-          <td class="right queued">{{ global.queued | group_thousands }}</td>
-        </tr>
-        {% if global.blocked and global.blocked != "0" %}
-        <tr>
-          <td class="left">Blocked</td>
-          <td class="bar-cell"><span class="bar-track"><span class="bar" style="--bar-width: {{global.blocked_percent}}%"></span></span></td>
-          <td class="right">{{ global.blocked_percent | float(default=0) | round }}%</td>
-          <td class="right">{{ global.blocked | group_thousands }}</td>
-        </tr>
-        {% endif %}
         <tr class="report-total">
-          <td class="left">Total</td>
-          <td></td>
-          <td class="right"></td>
-          <td class="right">{{ global.total | group_thousands }}</td>
+          <td class="left">Total processed</td>
+          <td class="bar-cell"></td>
+          <td class="right">100%</td>
+          <td class="right">{{ global.rerun_completed | group_thousands }}</td>
         </tr>
         {% if global.invalid and global.invalid != "0" %}
-        <tr class="report-muted">
-          <td class="left">Invalid <span class="report-sep">·</span> excluded from totals</td>
-          <td></td>
+        <tr class="report-muted corpus-report-invalid">
+          <td class="left"><a href="/corpus/{{global.corpus_name_uri}}/{{global.service_name_uri}}/invalid">Invalid</a> <span class="report-sep">·</span> excluded from totals</td>
+          <td class="bar-cell"></td>
           <td class="right"></td>
           <td class="right">{{ global.invalid | group_thousands }}</td>
         </tr>

--- a/templates/report.html.tera
+++ b/templates/report.html.tera
@@ -37,7 +37,7 @@
       {% endif %}
     </div>
     <table id="corpus-report" class="table report-table">
-      <caption class="report-caption">Outcomes <span class="report-sep">·</span> share of {{ global.rerun_completed | group_thousands }} processed</caption>
+      <caption class="report-caption">Results <span class="report-sep">·</span> share of {{ global.rerun_completed | group_thousands }} processed</caption>
       <thead>
         <tr>
           <th scope="col" class="left">Status</th>

--- a/templates/report.html.tera
+++ b/templates/report.html.tera
@@ -33,6 +33,7 @@
         <span class="report-sep">·</span> <span class="count-fatal">&minus;{{ global.livediff_regressed | group_thousands }} regressed</span>
         <span class="report-sep">·</span> <span class="count-ok">+{{ global.livediff_improved | group_thousands }} improved</span>
         <span class="report-sep">·</span> {{ global.livediff_unchanged | group_thousands }} unchanged
+        {% if global.livediff_reclassified and global.livediff_reclassified != "0" %}<span class="report-sep">·</span> <span class="report-muted">{{ global.livediff_reclassified | group_thousands }} reclassified</span>{% endif %}
       </p>
       {% endif %}
     </div>

--- a/templates/report.html.tera
+++ b/templates/report.html.tera
@@ -15,7 +15,7 @@
        always: the running quality mid-run, the final breakdown when done. Progress is shown
        apart so "awaiting"/"in progress" are not peers of the quality outcomes. #}
     <div class="report-progress">
-      <span class="bar-track" style="display:block;width:100%"><span class="bar ok" style="--bar-width: {{ global.processed_percent | default(value='0') }}%"></span></span>
+      <span class="bar-track" style="display:block;width:100%"><span class="bar progress" style="--bar-width: {{ global.processed_percent | default(value='0') }}%"></span></span>
       <p class="report-progress-summary">
         <strong>{{ global.rerun_completed | group_thousands }}</strong> of {{ global.total | group_thousands }} processed
         <span class="report-sep">·</span> {{ global.processed_percent | float(default=0) | round }}%
@@ -23,6 +23,18 @@
         {% if global.queued and global.queued != "0" %}<span class="report-sep">·</span> <a href="/workers/{{global.service_name_uri}}">{{ global.queued | group_thousands }} in&nbsp;progress</a>{% endif %}
         {% if global.blocked and global.blocked != "0" %}<span class="report-sep">·</span> {{ global.blocked | group_thousands }} blocked{% endif %}
       </p>
+      {# Live run-diff: of the processed-so-far tasks, how they moved vs the previous run's baseline
+         snapshot — an early divergence read. Shown only when a baseline exists and something has
+         completed (handler gates on compared > 0). Read-through cached, so it adds no per-load DB
+         cost. #}
+      {% if global.livediff_regressed %}
+      <p class="report-progress-summary report-livediff">
+        vs last run
+        <span class="report-sep">·</span> <span class="count-fatal">&minus;{{ global.livediff_regressed | group_thousands }} regressed</span>
+        <span class="report-sep">·</span> <span class="count-ok">+{{ global.livediff_improved | group_thousands }} improved</span>
+        <span class="report-sep">·</span> {{ global.livediff_unchanged | group_thousands }} unchanged
+      </p>
+      {% endif %}
     </div>
     <table id="corpus-report" class="table report-table">
       <caption class="report-caption">Outcomes <span class="report-sep">·</span> share of {{ global.rerun_completed | group_thousands }} processed</caption>


### PR DESCRIPTION
Replaces the two corpus-report tables with one. They were the **same counts under two denominators** (Rerun Progress over `completed`, Full Corpus over `total`) — identical at completion, divergent only mid-run where the over-total %s are diluted by pending work (the sole reason the second table existed). The split also listed "Awaiting processing" as a peer of "Fatal", conflating *progress* with *quality*.

**Unified design** (correct in every state):
- **Progress** line: processed / total + bar + awaiting / in-progress / blocked (handler emits new `processed_percent`).
- **Outcomes** table: no_problem/warning/error/fatal as a share of `completed` *always* — the running quality mid-run, the final breakdown when done — then Total processed + the discounted, clickable Invalid row.

Verified live: progress line + `Outcomes` table render; old headers gone; Invalid row + drill-down intact. **Subsumes #384** (clickable Invalid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)