### PR TITLE
chore(deps): drop dead direct deps hyper and tempfile (#69)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,6 @@ dependencies = [
  "figment",
  "flate2",
  "glob",
- "hyper 1.10.1",
  "infer",
  "libc",
  "percent-encoding",
@@ -527,7 +526,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
- "tempfile",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
@@ -1386,16 +1384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http 1.4.2",
-]
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,7 +1425,7 @@ dependencies = [
  "futures-util",
  "h2",
  "http 0.2.12",
- "http-body 0.4.6",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1447,18 +1435,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
-]
-
-[[package]]
-name = "hyper"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
-dependencies = [
- "bytes",
- "http 1.4.2",
- "http-body 1.0.1",
- "tokio",
 ]
 
 [[package]]
@@ -2645,7 +2621,7 @@ dependencies = [
  "either",
  "futures",
  "http 0.2.12",
- "hyper 0.14.32",
+ "hyper",
  "indexmap 2.14.0",
  "log",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 glob = "0.3.3"
 rand = "0.10.1"
-tempfile = "3"
 rocket = { version = "0.5.1", features = ["json"] }
 rocket_dyn_templates = { version = "0.2.0", features = ["tera"] }
-hyper = "1.10"
 percent-encoding = "2.3.2"
 zmq = "0.10.0"
 # Sharded, lock-free concurrent maps for the dispatcher's shared state (in-flight set + service


### PR DESCRIPTION
Part of the #69 cleanup wishlist ("stare at `cargo bloat` … remove dependencies to lighten the load").

`cargo-machete` flagged `hyper` and `tempfile` as unused direct deps; a whole-repo grep confirms it (the only `hyper` hit is the word *hyperthreaded* in a comment; `tempfile` has zero usage).

**Why it matters beyond a tidier manifest:** the direct `hyper = "1.10"` was the *only* edge pulling **hyper 1.x** into the tree — cortex's real HTTP stack is hyper 0.14 via Rocket 0.5. Removing it drops the duplicate `hyper 1.x` + `http-body 1.x` chain from the build entirely (`tempfile` remains transitively; `hyper 1.x` is gone). It also stops Dependabot from churning PRs against a direct dep we don't use.

`cargo check --workspace --all-targets` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)