### PR TITLE
chore(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204) + bytes to 1.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,9 +301,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bzip2"
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Why CI is red

On **2026-07-08**, `cargo-deny`'s advisories gate started failing on **every** CI run — including dependabot #395 (bytes) — the moment **RUSTSEC-2026-0204** was published. The advisory DB is fetched at runtime, so this is time-triggered, not diff-triggered; the bytes bump did not cause it.

**RUSTSEC-2026-0204** — invalid pointer dereference in the `fmt::Pointer`/`fmt::Display` impl for `Atomic`/`Shared` in **`crossbeam-epoch < 0.9.20`**, pulled in transitively (`zeromq-src → jwalk → crossbeam`, plus `ignore`/`tera`/`rayon`).

## What this does

Surgical, lockfile-only change (4 lines):

- **`crossbeam-epoch` 0.9.18 → 0.9.20** — the advisory's prescribed fix (`>= 0.9.20`).
- **`bytes` 1.12.0 → 1.12.1** — folds in the dependabot bump from #395.

Both bumps keep identical dependency lists. `main` currently still pins the vulnerable `crossbeam-epoch 0.9.18`, so its CI stays red until this lands.

## Verification

CI green on the branch: `build + test` ✅ · `cargo-deny (advisories + licenses)` ✅ (advisory cleared).

Supersedes / lets you close dependabot **#395** (its bytes bump is included here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)