### PR TITLE
Point worker-image refs at the published GHCR image

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -71,8 +71,20 @@ sudo apparmor_parser -r /etc/apparmor.d/gs
 
 Also ensure `ghostscript imagemagick poppler-utils mupdf-tools` are installed
 (the converter chain) and that ImageMagick's `policy.xml` permits PS/EPS/PDF.
-The Docker worker image (`docker/cortex-worker.dockerfile`) bakes all of this in
-and is unaffected by the host `gs` profile (it runs under `docker-default`).
+
+The **containerized worker** avoids all of the above — it bakes the
+gs/ImageMagick setup in and runs under `docker-default`, unaffected by the host
+`gs` profile. latexml-oxide publishes it to GHCR, built from its unified
+`Dockerfile --target worker`:
+
+```bash
+docker run --network host -v /opt/cortex-scratch:/opt/cortex-scratch \
+  --hostname="$(hostname)" ghcr.io/dginev/latexml-oxide/cortex-worker <dispatcher-host>
+```
+
+See latexml-oxide's `docker/README.md` for the full turnkey run reference
+(`PROFILE`/`WORKERS` env, standalone mode). The systemd units below run the
+bare-binary fleet instead (`WORKER_BIN` from a local `maxperf-cortex` build).
 
 ### Services
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -82,6 +82,9 @@ docker run --network host -v /opt/cortex-scratch:/opt/cortex-scratch \
   --hostname="$(hostname)" ghcr.io/dginev/latexml-oxide/cortex-worker <dispatcher-host>
 ```
 
+Published from latexml-oxide **0.7.4** onward — the unified `Dockerfile` postdates 0.7.3,
+which has no `worker` target. Each published release pushes `:<tag>` and `:latest`.
+
 See latexml-oxide's `docker/README.md` for the full turnkey run reference
 (`PROFILE`/`WORKERS` env, standalone mode). The systemd units below run the
 bare-binary fleet instead (`WORKER_BIN` from a local `maxperf-cortex` build).

--- a/deploy/apparmor/local-gs
+++ b/deploy/apparmor/local-gs
@@ -23,7 +23,8 @@
 #
 # (Docker deployments do NOT need this: the container runs under Docker's
 # `docker-default` AppArmor profile, not the host per-binary `gs` profile, and
-# the image now installs ghostscript explicitly — see docker/cortex-worker.dockerfile
+# the image installs ghostscript explicitly — see the unified `Dockerfile`
+# (`--target worker`, published as ghcr.io/dginev/latexml-oxide/cortex-worker)
 # in the latexml-oxide repo.)
 
   owner file rw /opt/cortex-scratch/**,


### PR DESCRIPTION
latexml-oxide consolidated its three Dockerfiles into one unified root `Dockerfile` (`--target cli` / `--target worker`) and now publishes the CorTeX worker image to `ghcr.io/dginev/latexml-oxide/cortex-worker`.

- Deploy README's containerized-worker note now documents `docker run ghcr.io/dginev/latexml-oxide/cortex-worker`, with a pointer to the systemd bare-binary fleet as the alternative.
- `apparmor/local-gs` comment points at the unified Dockerfile instead of the deleted `docker/cortex-worker.dockerfile`.

Docs only — no change to the production systemd + bare-binary fleet path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)